### PR TITLE
Fix some inconsistent data access in HTML templates

### DIFF
--- a/templates/item/item-ability-sheet.html
+++ b/templates/item/item-ability-sheet.html
@@ -5,13 +5,13 @@
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
             <div class="grid grid-col">
                 <div class="resource">
-                    <label>{{localize "arm5e.sheet.speciality"}}<input type="text" name="data.speciality"  value="{{item.data.data.speciality}}"  data-dtype="String" /></label>
+                    <label>{{localize "arm5e.sheet.speciality"}}<input type="text" name="data.speciality"  value="{{data.speciality}}"  data-dtype="String" /></label>
                 </div>
                 <div class="resource">
-                    <label>{{localize "arm5e.sheet.score"}}<input type="text" name="data.score"  value="{{item.data.data.score}}"  data-dtype="Number" /></label>
+                    <label>{{localize "arm5e.sheet.score"}}<input type="text" name="data.score"  value="{{data.score}}"  data-dtype="Number" /></label>
                 </div>
                 <div class="resource">
-                    <label>{{localize "arm5e.sheet.experience"}}<input type="text" name="data.experience"  value="{{item.data.data.experience}}"  data-dtype="Number" /></label>
+                    <label>{{localize "arm5e.sheet.experience"}}<input type="text" name="data.experience"  value="{{data.experience}}"  data-dtype="Number" /></label>
                 </div>
             </div>
         </div>
@@ -31,7 +31,7 @@
 
         {{!-- Description Tab --}}
         <div class="tab" data-group="primary" data-tab="description">
-            {{editor content=item.data.data.description target="item.data.data.description" button=true owner=owner editable=editable}}
+            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
         </div>
 
     </section>

--- a/templates/item/item-weapon-sheet.html
+++ b/templates/item/item-weapon-sheet.html
@@ -76,8 +76,8 @@
                 <div class="resource flexcol">
                   <label for="data.cost.value" class="header-label">{{localize "arm5e.sheet.cost"}}</label>
                   <select name="data.cost.value"  data-type="String">
-                    {{#select item.data.data.cost.value}}
-                    {{#each item.data.data.costs as |costs key|}}
+                    {{#select data.cost.value}}
+                    {{#each data.costs as |costs key|}}
                     <option value="{{key}}">{{localize costs.label}}</option> {{/each}} {{/select}}
                   </select>
                 </div>


### PR DESCRIPTION
Some templates accessed data with `item.data.data.prop` rather than directly `data.prop` . this worked for most cases, but caused issues with ability description edition