### PR TITLE
- PC and NPC now store soak and size at the same place (migration nee…

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -28,6 +28,10 @@ Features
 - dead characters are no longer able to roll
 - unconscious characters are only able to roll characteristics rolls
 - new "Rest" button to recover all fatigue levels
+- PC and NPC now store soak and size at the same place (migration needed for NPCs)
+- Soak field is now readonly and computed automatically based on stamina and equiped armor
+- NPCs of type entity only have powers. Those only a might cost and a form (for magical resistance)
+- Vis sources and books now have their metadata available (sourcebook and page).
 
 Bug fixes
 - fixed a bug where results of a stress die were always 0 on a 10 even if there was no botch 
@@ -41,6 +45,7 @@ Bug fixes
 - moved covenant Calendar to diary tab
 - fixed magicaL focus casting total computation
 - labels of covenant build points are properly displayed again.
+- Fixed problem with Might type not saved for npc entities
 
 
 1.2.3

--- a/lang/en.json
+++ b/lang/en.json
@@ -475,6 +475,9 @@
     "arm5e.notification.unconscious": "This character is unconscious, no action possible...",
     "arm5e.notification.dead": "This character is dead...",
 
+    "arm5e.packs.abilities.name": "Abilities",
+
+
     "arm5e.sheet.source.ArM5": "Core Book",
     "arm5e.sheet.source.RoP:D": "Realms of Power: The Divine",
     "arm5e.sheet.source.RoP:I": "Realms of Power: The Infernal",

--- a/module/actor/actor-pc.js
+++ b/module/actor/actor-pc.js
@@ -60,6 +60,8 @@ export class ArM5ePCActor extends Actor {
         let abilitiesFamiliar = [];
         let powersFamiliar = [];
 
+        let soak = actorData.data.characteristics.sta.value;
+
         let powers = [];
 
         let specialities = [];
@@ -88,6 +90,8 @@ export class ArM5ePCActor extends Actor {
         };
 
         const data = actorData.data;
+
+
 
         if (data.fatigue) {
             data.fatigueTotal = 0;
@@ -263,6 +267,11 @@ export class ArM5ePCActor extends Actor {
                 }
             }
         }
+
+        if (combat.prot) {
+            soak += combat.prot;
+        }
+
         if (combat.overload < 0) {
             combat.overload = 0;
         }
@@ -354,6 +363,10 @@ export class ArM5ePCActor extends Actor {
             } else {
                 actorData.data.magicalEffects = magicalEffects;
             }
+        }
+
+        if (actorData.data.vitals.soa.value) {
+            actorData.data.vitals.soa.value = soak;
         }
 
         if (actorData.data.vis) {
@@ -677,27 +690,17 @@ export class ArM5ePCActor extends Actor {
         this.update(updateData, {});
     }
 
-    rest() {
+    async rest() {
         if ((this.data.type != 'player') && (this.data.type != 'npc')) {
             return;
         }
         let updateData = {};
-        if (this.data.data.fatigue.winded.level.value == true) {
-            updateData["data.fatigue.winded.level.value"] = false;
-        }
-        if (this.data.data.fatigue.weary.level.value == true) {
-            updateData["data.fatigue.weary.level.value"] = false;
-        }
-        if (this.data.data.fatigue.tired.level.value == true) {
-            updateData["data.fatigue.tired.level.value"] = false;
-        }
-        if (this.data.data.fatigue.dazed.level.value == true) {
-            updateData["data.fatigue.dazed.level.value"] = false;
-        }
-        if (this.data.data.fatigue.unconscious.level.value == true) {
-            updateData["data.fatigue.unconscious.level.value"] = false;
-        }
-        this.update(updateData, {});
+        updateData["data.fatigue.winded.level.value"] = false;
+        updateData["data.fatigue.weary.level.value"] = false;
+        updateData["data.fatigue.tired.level.value"] = false;
+        updateData["data.fatigue.dazed.level.value"] = false;
+        updateData["data.fatigue.unconscious.level.value"] = false;
+        await this.update(updateData, {});
     }
 
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -209,26 +209,46 @@ export class ArM5eActorSheet extends ActorSheet {
 
 
         // Generate abiliy automatically
-        html.find('.abilities-generate').click(ev => {
-            let charType = this.actor.data.data.charType.value;
-            if (charType === "magus" || charType === "magusNPC") {
-                let abilities = this.actor.items.filter(i => i.type == "ability");
-                let newAbilities = [];
-                for (let [key, a] of Object.entries(CONFIG.ARM5E.character.abilities)) {
-                    // if the ability doesn't exists create it
-                    let abs = abilities.filter(ab => ab.data.name == game.i18n.localize(a))
-                    if (abs.length == 0) {
-                        log(false, `Did not find ${game.i18n.localize(a)}, creating it...`);
-                        const itemData = {
-                            name: game.i18n.localize(a),
-                            type: "ability"
-                        };
-                        newAbilities.push(itemData);
-                    }
-                }
-                this.actor.createEmbeddedDocuments("Item", newAbilities, {});
-            }
-        });
+        // html.find('.abilities-generate').click(ev => {
+        //     let charType = this.actor.data.data.charType.value;
+        //     let updateData = {};
+        //     if (charType === "magus" || charType === "magusNPC") {
+        //         let abilities = this.actor.items.filter(i => i.type == "ability");
+        //         let newAbilities = [];
+        //         for (let [key, a] of Object.entries(CONFIG.ARM5E.character.abilities)) {
+        //             let localizedA = game.i18n.localize(a);
+        //             let abs = abilities.filter(ab => ab.name == localizedA || ab.name === localizedA + "*")
+
+        //             if (abs.length == 0) {
+        //                 log(false, `Did not find ${game.i18n.localize(a)}, creating it...`);
+        //                 const itemData = {
+        //                     name: localizedA,
+        //                     type: "ability"
+        //                 };
+        //                 // First, check if the Ability is found in the world
+        //                 abs = game.items.filter(i => i.type === "ability" && (i.name === localizedA || i.name === localizedA + "*"));
+        //                 if (abs.length == 0) {
+        //                     // Then, check if the Abilities compendium exists
+        //                     let abPack = game.packs.filter(p => p.metadata.package === "arm5e" && p.metadata.name === "Abilities")
+
+        //                     for (let p of game.packs) {
+        //                         if (p.metadata.package !== "arm5e") continue;
+
+        //                     }
+
+        //                 } else {
+        //                     itemData.data = foundry.utils.deepClone(abs[0].data)
+        //                 }
+
+        //                 newAbilities.push(itemData);
+
+        //             } else { // found the ability, assign its Id
+        //                 updataData[`data.laboratoryPC.abilitiesSelected.${i.name}`]._id = abs[0]._id;
+        //             }
+        //         }
+        //         this.actor.createEmbeddedDocuments("Item", newAbilities, {});
+        //     }
+        // });
 
         html.find('.rest').click(ev => {
             if (this.actor.data.type === "player" || this.actor.data.type === "npc") {

--- a/module/migration.js
+++ b/module/migration.js
@@ -199,6 +199,15 @@ export const migrateActorData = function(actorData) {
         updateData["data.-=mights"] = null;
     }
 
+    if (actorData.data.soak) {
+        updateData["data.vitals.soa.value"] = actorData.data.soak.value;
+        updateData["data.-=soak"] = null;
+    }
+
+    if (actorData.data.size) {
+        updateData["data.vitals.siz.value"] = actorData.data.size.value;
+        updateData["data.-=size"] = null;
+    }
 
     // remove redundant data
     if (actorData.data.houses != undefined) {

--- a/template.json
+++ b/template.json
@@ -121,6 +121,17 @@
                         "score": "0"
                     }
                 },
+                "vitals": {
+                    "siz": {
+                        "value": 0
+                    },
+                    "soa": {
+                        "value": 0
+                    },
+                    "enc": {
+                        "value": 0
+                    }
+                },
                 "abilities": [],
                 "weapons": [],
                 "armor": [],
@@ -140,17 +151,6 @@
                     "value": "",
                     "label": "Season",
                     "dtype": "String"
-                },
-                "vitals": {
-                    "siz": {
-                        "value": 0
-                    },
-                    "soa": {
-                        "value": 0
-                    },
-                    "enc": {
-                        "value": 0
-                    }
                 },
                 "year": {
                     "label": "Year",
@@ -708,11 +708,6 @@
                 "value": "mundane",
                 "label": "Char. Type"
             },
-            "size": {
-                "label": "Size",
-                "dtype": "Number",
-                "value": 0
-            },
             "house": {
                 "value": "gen",
                 "label": "House"
@@ -723,15 +718,11 @@
                 "points": 0,
                 "effects": "Warping effects"
             },
-            "soak": {
-                "label": "soak",
-                "dtype": "Number",
-                "value": 0
-            },
             "might": {
                 "label": "Might",
                 "dtype": "Number",
-                "value": 0
+                "value": 0,
+                "type": "magic"
             },
             "powers": []
         },
@@ -1242,8 +1233,10 @@
             "experience": 0,
             "activity": ""
         },
-        "might": {
-            "templates": ["base"]
+        "power": {
+            "templates": ["base"],
+            "form": "an",
+            "cost": 0
         },
         "mightFamiliar": {
             "templates": ["base"]

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -25,7 +25,7 @@
                     <div class="resource-content flexrow flex-center flex-between">
                         <input type="text" name="data.might.value" value="{{data.might.value}}" data-dtype="Number" style="padding-top:4px; margin-left: 8px; margin-right: 10px;" />
                         <select name="data.might.type" data-type="String">
-                            {{#select data.typeAura}}
+                            {{#select data.might.type}}
                                 {{#each metadata.realms as |realm key|}}
                                     <option value="{{key}}">{{localize realm.label}}</option>
                                 {{/each}} {{/select}}
@@ -61,16 +61,16 @@
                 </div>
 
                 <div class="resource flex-group-center backSection">
-                    <label for="data.size.value" class="smallTitle">{{localize "arm5e.sheet.size"}}</label>
+                    <label for="data.vitals.siz.value" class="smallTitle">{{localize "arm5e.sheet.size"}}</label>
                     <div class="resource-content flexrow flex-center flex-between margintop6">
-                        <input type="text" name="data.size.value" value="{{data.size.value}}" data-dtype="Number" />
+                        <input type="text" name="data.vitals.siz.value" value="{{data.vitals.siz.value}}" data-dtype="Number" />
                     </div>
                 </div>
 
                 <div class="resource flex-group-center backSection">
-                    <label for="data.soak.value" class="smallTitle">{{localize "arm5e.sheet.soak"}}</label>
+                    <label for="data.vitals.soa.value" class="smallTitle">{{localize "arm5e.sheet.soak"}}</label>
                     <div class="resource-content flexrow flex-center flex-between">
-                        <input type="text" name="data.soak.value" value="{{data.soak.value}}" data-dtype="Number" />
+                        <input type="text" name="data.vitals.soa.value" value="{{data.vitals.soa.value}}" data-dtype="Number" readonly />
                     </div>
                 </div>
                 <div class="resource flex-group-center backSection">

--- a/templates/actor/parts/actor-arts.html
+++ b/templates/actor/parts/actor-arts.html
@@ -1,81 +1,81 @@
-<div class="flexrow grid grid-3col backSection">
-    <div>
-        <ol style="padding: 0 1em 0 1em;">
-            <li class="flexrow">
-                <div class=" width15"><span class="smallTitle">{{localize "arm5e.sheet.techniques"}}</span><span>
-                        ({{ data.totalXPArts }}xp)</span></div>
-            </li>
-            {{#each data.arts.techniques as |techniques key|}}
-                <li class="flexrow" data-attribute="{{key}}">
-                    <span class="flex03">
-                        {{#if (eq @root.artsIcons "symbol")}}
-                            <img src="/systems/arm5e/assets/magic/{{key}}.png" style="border: 0px; height: 40px;" />
-                        {{else}}
-                            <img src="/systems/arm5e/assets/hands/{{key}}.png" style="border: 0px; height: 40px;" />
-                        {{/if}}
-                    </span>
-                    <div class="flexcol">
-                        <div class="flexrow marginbot4">
-                            <span class="flexrow fontSize10 rollable" name="data.arts.techniques.{{key}}.label" data-roll="spont" data-technique="{{key}}"" data-divide=2>
-                                {{label}}
-                            </span>
-                            <input class=" flex05" type="text" name="data.arts.techniques.{{key}}.score" value="{{techniques.score}}" data-dtype="Number">
-                        </div>
-                        <div class="flexrow">
-                            <span class="flexrow marginbot12">
-                                <label class="fontSize8">{{localize "arm5e.sheet.experienceShort"}}</label>
-                                <input class="flex03" type="text" name="data.arts.techniques.{{key}}.experience" value="{{techniques.experience}}" data-dtype="Number"> &nbsp;/ {{ techniques.experienceNextLevel }}
-                            </span>
-                        </div>
-                    </div>
+{{#if (ne data.charType.value "entity")}}
+    <div class="flexrow grid grid-3col backSection">
+        <div>
+            <ol style="padding: 0 1em 0 1em;">
+                <li class="flexrow">
+                    <div class=" width15"><span class="smallTitle">{{localize "arm5e.sheet.techniques"}}</span><span>
+                            ({{ data.totalXPArts }}xp)</span></div>
                 </li>
-            {{/each}}
-        </ol>
-    </div>
-
-    <div>
-        <ol style="padding: 0 1em 0 1em;">
-            <li class="flexrow">
-                <label class="smallTitle width15">{{localize "arm5e.sheet.forms"}}</label>
-            </li>
-            {{#each data.arts.forms as |forms key|}}
-                <li class="flexrow" data-attribute="{{key}}">
-                    <span class="flex03">
-                        <a class="flex01 link" href="/systems/arm5e/pdf/spells/{{key}}.pdf" target="_blank">
+                {{#each data.arts.techniques as |techniques key|}}
+                    <li class="flexrow" data-attribute="{{key}}">
+                        <span class="flex03">
                             {{#if (eq @root.artsIcons "symbol")}}
                                 <img src="/systems/arm5e/assets/magic/{{key}}.png" style="border: 0px; height: 40px;" />
                             {{else}}
                                 <img src="/systems/arm5e/assets/hands/{{key}}.png" style="border: 0px; height: 40px;" />
                             {{/if}}
-                        </a>
-                    </span>
-                    <div class="flexcol">
-                        <div class="flexrow marginbot4">
-                            <span class="flexrow fontSize10 rollable" name="data.arts.forms.{{key}}.label" data-roll="spont" data-mform="{{key}}" data-divide=2>
-                                {{label}}&nbsp;({{ forms.magicResistance }})
+                        </span>
+                        <div class="flexcol">
+                            <div class="flexrow marginbot4">
+                                <span class="flexrow fontSize10 rollable" name="data.arts.techniques.{{key}}.label" data-roll="spont" data-technique="{{key}}"" data-divide=2>
+                                {{label}}
                             </span>
-                            <input class="flex05" type="text" name="data.arts.forms.{{key}}.score" value="{{forms.score}}" data-dtype="Number">
+                            <input class=" flex05" type="text" name="data.arts.techniques.{{key}}.score" value="{{techniques.score}}" data-dtype="Number">
+                            </div>
+                            <div class="flexrow">
+                                <span class="flexrow marginbot12">
+                                    <label class="fontSize8">{{localize "arm5e.sheet.experienceShort"}}</label>
+                                    <input class="flex03" type="text" name="data.arts.techniques.{{key}}.experience" value="{{techniques.experience}}" data-dtype="Number"> &nbsp;/ {{ techniques.experienceNextLevel }}
+                                </span>
+                            </div>
                         </div>
-                        <div class="flexrow">
-                            <span class="flexrow marginbot12">
-                                <label class="fontSize8">{{localize "arm5e.sheet.experienceShort"}}</label>
-                                <input class="flex03" type="text" name="data.arts.forms.{{key}}.experience" value="{{forms.experience}}" data-dtype="Number"> &nbsp;/ {{ forms.experienceNextLevel }}
-                            </span>
-                        </div>
-                    </div>
+                    </li>
+                {{/each}}
+            </ol>
+        </div>
+
+        <div>
+            <ol style="padding: 0 1em 0 1em;">
+                <li class="flexrow">
+                    <label class="smallTitle width15">{{localize "arm5e.sheet.forms"}}</label>
                 </li>
-                {{#if (eq key "he")}}
-        </ol>
-    </div>
-    <div>
-        <ol style="padding: 0 1em 0 1em;">
-            <li class="flexrow">
-                <label class="smallTitle width15">{{localize "arm5e.sheet.forms"}}</label>
-            </li>
-            {{/if}}
-            {{/each}}
-        </ol>
-    </div>
+                {{#each data.arts.forms as |forms key|}}
+                    <li class="flexrow" data-attribute="{{key}}">
+                        <span class="flex03">
+                            <a class="flex01 link" href="/systems/arm5e/pdf/spells/{{key}}.pdf" target="_blank">
+                                {{#if (eq @root.artsIcons "symbol")}}
+                                    <img src="/systems/arm5e/assets/magic/{{key}}.png" style="border: 0px; height: 40px;" />
+                                {{else}}
+                                    <img src="/systems/arm5e/assets/hands/{{key}}.png" style="border: 0px; height: 40px;" />
+                                {{/if}}
+                            </a>
+                        </span>
+                        <div class="flexcol">
+                            <div class="flexrow marginbot4">
+                                <span class="flexrow fontSize10 rollable" name="data.arts.forms.{{key}}.label" data-roll="spont" data-mform="{{key}}" data-divide=2>
+                                    {{label}}&nbsp;({{ forms.magicResistance }})
+                                </span>
+                                <input class="flex05" type="text" name="data.arts.forms.{{key}}.score" value="{{forms.score}}" data-dtype="Number">
+                            </div>
+                            <div class="flexrow">
+                                <span class="flexrow marginbot12">
+                                    <label class="fontSize8">{{localize "arm5e.sheet.experienceShort"}}</label>
+                                    <input class="flex03" type="text" name="data.arts.forms.{{key}}.experience" value="{{forms.experience}}" data-dtype="Number"> &nbsp;/ {{ forms.experienceNextLevel }}
+                                </span>
+                            </div>
+                        </div>
+                    </li>
+                    {{#if (eq key "he")}}
+            </ol>
+        </div>
+        <div>
+            <ol style="padding: 0 1em 0 1em;">
+                <li class="flexrow">
+                    <label class="smallTitle width15">{{localize "arm5e.sheet.forms"}}</label>
+                </li>
+{{/if}} {{/each}}
+</ol>
+</div>
 </div>
 
 {{> "systems/arm5e/templates/actor/parts/actor-laboratoryTotals.html" show="arts" }}
@@ -178,8 +178,7 @@
         {{/each}}
     </ol>
 </div>
-
-{{#if (eq actor.type "npc")}}
+{{else}}
     <div class="flexrow backSection margintop18">
         <ol class="items-list">
             <li class="item flexrow item-header">
@@ -198,6 +197,12 @@
                         <span class="flexrow item-title width4" name="item.name">
                             {{item.name}}
                         </span>
+                        <span class="bold" name="item.name">
+                            {{#with (lookup @root.metadata.magic.forms item.data.form)~}}{{label~}}{{/with}}
+                        </span>
+                        <span class="bold" name="item.name">
+                            {{item.data.cost }} {{localize "arm5e.sheet.points"}}
+                        </span>
                     </div>
                     <div class="item-controls">
                         <a class="item-control item-edit" title="Edit power"><i class="fas fa-edit"></i></a>
@@ -207,6 +212,7 @@
             {{/each}}
         </ol>
     </div>
-{{/if}}
-
-{{> "systems/arm5e/templates/actor/parts/actor-setAbilities.html" }}
+    {{/if}}
+    {{#if (ne data.charType.value "entity")}}
+        {{> "systems/arm5e/templates/actor/parts/actor-setAbilities.html" }}
+    {{/if}}

--- a/templates/actor/parts/actor-description.html
+++ b/templates/actor/parts/actor-description.html
@@ -112,7 +112,13 @@
                         {{#with (lookup @root.metadata.character.vitals key)}}
                             <label for="data.vitals.{{key}}.label" class="bold">{{localize label}}</label>
                         {{/with}}
-                        <span><input type="text" name="data.vitals.{{key}}.value" value="{{numberFormat vitals.value decimals=0 sign=true}}" data-dtype="Number" /></span>
+                        <span>
+                            {{#if (eq key "soa")}}
+                                <input type="text" name="data.vitals.{{key}}.value" value="{{numberFormat vitals.value decimals=0 sign=true}}" data-dtype="Number" readonly />
+                            {{else}}
+                                <input type="text" name="data.vitals.{{key}}.value" value="{{numberFormat vitals.value decimals=0 sign=true}}" data-dtype="Number" />
+                            {{/if}}
+                        </span>
                     </div>
                 {{/each}}
             </div>

--- a/templates/item/item-book-sheet.html
+++ b/templates/item/item-book-sheet.html
@@ -9,8 +9,8 @@
                     <label for="data.art.value" class="header-label">{{localize "arm5e.sheet.art"}}</label>
                     <select name="data.art.value" data-type="String">
                         {{#select data.art.value}}
-                            {{#each metadata.magic.arts as |techniques key|}}
-                                <option value="{{key}}">{{techniques.label}}</option>
+                            {{#each metadata.magic.arts as |art key|}}
+                                <option value="{{key}}">{{art.label}}</option>
                             {{/each}} {{/select}}
                     </select>
                 </div>

--- a/templates/item/item-power-sheet.html
+++ b/templates/item/item-power-sheet.html
@@ -1,9 +1,22 @@
 <form class="{{cssClass}} mainItem" autocomplete="off">
     {{> "systems/arm5e/templates/item/parts/item-header.html" }}
     <header class="sheet-header">
-
+        <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="name" /></h1>
+            <div class="resource flexcol flexrow">
+                <label for="data.form" class="header-label">{{localize "arm5e.sheet.form"}}</label>
+                <select name="data.form" data-type="String">
+                    {{#select data.form}}
+                        {{#each metadata.magic.forms as |form key|}}
+                            <option value="{{key}}">{{form.label}}</option>
+                        {{/each}} {{/select}}
+                </select>
+            </div>
+            <div class="resource flexcol flexrow">
+                <label for="data.cost" class="header-label">{{localize "arm5e.sheet.cost"}}</label>
+                <input name="data.cost" type="text" value="{{data.cost}}" placeholder="0" />
+            </div>
         </div>
     </header>
 
@@ -23,16 +36,7 @@
         <div class="tab" data-group="primary" data-tab="description">
             {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
             {{#if (eq metagame true)}}
-                <div class="grid grid-2col">
-                    <div class="resource">
-                        <label class="header-label">{{localize "arm5e.sheet.source.label"}}</label>
-                        <input type="text" name="data.source" value="{{data.source}}" data-dtype="String" />
-                    </div>
-                    <div class="resource">
-                        <label class="header-label">{{localize "arm5e.sheet.page"}}</label>
-                        <input type="text" name="data.page" value="{{data.page}}" data-dtype="Number" />
-                    </div>
-                </div>
+                {{> "systems/arm5e/templates/generic/source.html" }}
             {{/if}}
         </div>
 

--- a/templates/item/item-visSourcesCovenant-sheet.html
+++ b/templates/item/item-visSourcesCovenant-sheet.html
@@ -63,16 +63,7 @@
         <div class="tab" data-group="primary" data-tab="description">
             {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
             {{#if (eq metagame true)}}
-                <div class="grid grid-2col">
-                    <div class="resource">
-                        <label class="header-label">{{localize "arm5e.sheet.source.label"}}</label>
-                        <input type="text" name="data.source" value="{{data.source}}" data-dtype="String" />
-                    </div>
-                    <div class="resource">
-                        <label class="header-label">{{localize "arm5e.sheet.page"}}</label>
-                        <input type="text" name="data.page" value="{{data.page}}" data-dtype="Number" />
-                    </div>
-                </div>
+                {{> "systems/arm5e/templates/generic/source.html" }}
             {{/if}}
         </div>
 


### PR DESCRIPTION
…ded for NPCs)

- Soak field is now readonly and computed automatically based on stamina and equiped armor
- NPCs of type entity only have powers. Those only a might cost and a form (for magical resistance)
- Vis sources and books now have their metadata available (sourcebook and page).
- Fixed problem with Might type not saved for npc entities
- Disabled abilities generation button for the moment