### PR TITLE
Bugfix/calculate damage and wound

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -512,6 +512,7 @@
     "arm5e.notification.codex.enchant": "You need a Codex actor with enchantments to enchant this way.",
     "arm5e.notification.crucible.no.invest.possible": "Item's size and material are not good enough for this level of enchantment.",
     "arm5e.notification.crucible.labTotal.needed": "Lab total needed",
+    "arm5e.notification.notPossibleToCalculateWound": "We cannot calculate the wound (check the size of your actor)",
     "arm5e.packs.abilities.name": "Abilities",
 
 
@@ -561,6 +562,6 @@
     "arm5e.messages.wound.heavy": "heavy",
     "arm5e.messages.wound.incap": "incap",
     "arm5e.messages.wound.dead": "dead",
-    "arm5e.messages.wound": "Got a $typeWound$ wound"
-
+    "arm5e.messages.wound": "Got a $typeWound$ wound",
+    "arm5e.messages.noWound": "No wound inflicted"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -317,12 +317,12 @@
     "arm5e.messages.wound.heavy": "Grave",
     "arm5e.messages.wound.incap": "Incapacitante",
     "arm5e.messages.wound.dead": "Muerto",
+    "arm5e.messages.noWound": "No se causó ninguna herida",
 
     "arm5e.messages.woundResult": "Recibió una herida $typeWound$",
     "arm5e.dialog.chooseCovenant": "Elegir alianza",
 
     "arm5e.dialog.damageCalculator": "Calculadora de daño",
-    "arm5e.dialog.woundCalculator": "Calculadora de heridas"
-
-
+    "arm5e.dialog.woundCalculator": "Calculadora de heridas",
+    "arm5e.notification.notPossibleToCalculateWound": "No se puede calcular la herida (comprueba el tamaño de tu actor)"
 }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -374,10 +374,10 @@ export class ArM5eActorSheet extends ActorSheet {
         const lastMessageDamage = getLastMessageByHeader(game, 'arm5e.sheet.damage');
         const damage = parseInt(
             $(lastMessageDamage?.data?.content).text()
-        );
+        ) || 0;
         debugger;
         const extraData = {
-            damage: damage || 0,
+            damage,
             modifier: 0,
         }
 

--- a/module/tools.js
+++ b/module/tools.js
@@ -143,11 +143,15 @@ export function getLastMessageByHeader(game, key) {
         const flavor = (msg?.data?.flavor || '').toLowerCase();
         return flavor.indexOf(searchString) > -1;
     });
-    return messages.pop();
+    if(messages.length) return messages.pop();
+    return false;
 }
 
 
 export function calculateWound(damage, size) {
+    if(damage < 0) {
+        return '';
+    }
     const sizesAndWounds =
     {
         "-4": {
@@ -209,10 +213,10 @@ export function calculateWound(damage, size) {
     }
 
     const typeOfWoundsBySize = sizesAndWounds[size.toString()];
-
+    if(typeOfWoundsBySize === undefined) return false;
     const wounds = Object.keys(typeOfWoundsBySize);
 
-    let typeOfWound = ''
+    let typeOfWound = false;
     wounds.forEach((wound) => {
         if (Number(wound) < damage) {
             typeOfWound = typeOfWoundsBySize[wound];


### PR DESCRIPTION
Couple of fixes:
- When calculating damage, if we don't find attack or defense messages, we default to 0
- When calculating soak, if we don't find damage messages we default to 0
- When calculating wounds, if:
  + Damage is less than soak, we put "No wounds" in chat
  + Wound cannot be calculated (mostly because of size), we put a notification in the UI telling so