### PR TITLE
Improve safety of the new laboratory features

### DIFF
--- a/module/actor/actor-pc.js
+++ b/module/actor/actor-pc.js
@@ -112,6 +112,7 @@ export class ArM5ePCActor extends Actor {
           flags: {
             arm5e: {
               baseSafetyEffect: true,
+              noEdit: true,
               type: ["laboratory"],
               subtype: ["safety"],
               option: [null]

--- a/module/helpers/active-effects.js
+++ b/module/helpers/active-effects.js
@@ -18,7 +18,8 @@ export default class ArM5eActiveEffect extends ActiveEffect {
     // if the effect is from an Item (virtue, etc) and is owned, prevent edition
     this.data.noEdit =
       (this.parent.documentName === "Item" && this.parent.isOwned == true) ||
-      (this.parent.documentName === "Actor" && this.data.origin?.includes("Item"));
+      (this.parent.documentName === "Actor" && this.data.origin?.includes("Item")) ||
+      (this.getFlag("arm5e", "noEdit"));
   }
 
   /** @inheritdoc */

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -83,6 +83,39 @@ export class ArM5eItemSheet extends ItemSheet {
       context.abilityKeysList = CONFIG.ARM5E.ALL_ABILITIES;
     }
 
+    if (itemData.type == "flaw" || itemData.type == "virtue") {
+      if (context.item.parent) {
+        switch (context.item.parent.data.type) {
+          case "laboratory":
+            context.metadata.virtueFlawTypes.available = {
+              ...context.metadata.virtueFlawTypes.laboratory,
+              ...context.metadata.virtueFlawTypes.all
+            };
+            break;
+          case "covenant":
+            context.metadata.virtueFlawTypes.available = {
+              ...context.metadata.virtueFlawTypes.covenant,
+              ...context.metadata.virtueFlawTypes.all
+            };
+            break;
+          case "player":
+          case "npc": 
+            context.metadata.virtueFlawTypes.available = {
+            ...context.metadata.virtueFlawTypes.character,
+            ...context.metadata.virtueFlawTypes.all
+          };
+            break;
+        }
+      } else {
+        context.metadata.virtueFlawTypes.available = {
+          ...context.metadata.virtueFlawTypes.character,
+          ...context.metadata.virtueFlawTypes.laboratory,
+          ...context.metadata.virtueFlawTypes.covenant,
+          ...context.metadata.virtueFlawTypes.all
+        };
+      }
+    }
+
     context.metagame = game.settings.get("arm5e", "metagame");
 
     context.devMode = game.modules.get("_dev-mode")?.api?.getPackageDebugValue(CONFIG.ARM5E.MODULE_ID);

--- a/module/metadata.js
+++ b/module/metadata.js
@@ -244,70 +244,15 @@ ARM5E.character.description = {
   }
 };
 
-ARM5E.character.virtueTypes = {
-  hermetic: {
-    label: "arm5e.sheet.hermetic"
-  },
-  supernatural: {
-    label: "arm5e.sheet.supernatural"
-  },
-  social: {
-    label: "arm5e.sheet.socialStatus"
-  },
-  general: {
-    label: "arm5e.sheet.general"
-  },
-  child: {
-    label: "arm5e.sheet.child"
-  },
-  heroic: {
-    label: "arm5e.sheet.heroic"
-  },
-  mystery: {
-    label: "arm5e.sheet.mystery"
-  },
-  tainted: {
-    label: "arm5e.sheet.tainted"
-  },
-  initiations: {
-    label: "arm5e.sheet.initiations"
-  },
-  qualities: {
-    label: "arm5e.sheet.qualities"
-  },
-  magicqualities: {
-    label: "arm5e.sheet.magicqualities"
-  },
-  laboratoryStructure: {
-    label: "arm5e.sheet.laboratoryStructure"
-  },
-  laboratoryOutfitting: {
-    label: "arm5e.sheet.laboratoryOutfitting"
-  },
-  laboratorySupernatural: {
-    label: "arm5e.sheet.laboratorySupernatural"
-  },
-  covenantSite: {
-    label: "arm5e.sheet.covenantSite"
-  },
-  covenantResources: {
-    label: "arm5e.sheet.covenantResources"
-  },
-  covenantResidents: {
-    label: "arm5e.sheet.covenantResidents"
-  },
-  covenantExternalRelations: {
-    label: "arm5e.sheet.covenantExternalRelations"
-  },
-  covenantSurroundings: {
-    label: "arm5e.sheet.covenantSurroundings"
-  },
+ARM5E.virtueFlawTypes = {};
+
+ARM5E.virtueFlawTypes.all = {
   other: {
     label: "arm5e.sheet.other"
   }
 };
 
-ARM5E.character.flawTypes = {
+ARM5E.virtueFlawTypes.character = {
   hermetic: {
     label: "arm5e.sheet.hermetic"
   },
@@ -334,7 +279,10 @@ ARM5E.character.flawTypes = {
   },
   tainted: {
     label: "arm5e.sheet.tainted"
-  },
+  }
+};
+
+ARM5E.virtueFlawTypes.laboratory = {
   laboratoryStructure: {
     label: "arm5e.sheet.laboratoryStructure"
   },
@@ -343,6 +291,12 @@ ARM5E.character.flawTypes = {
   },
   laboratorySupernatural: {
     label: "arm5e.sheet.laboratorySupernatural"
+  },
+};
+
+ARM5E.virtueFlawTypes.covenant = {
+  general: {
+    label: "arm5e.sheet.general"
   },
   covenantSite: {
     label: "arm5e.sheet.covenantSite"
@@ -359,9 +313,6 @@ ARM5E.character.flawTypes = {
   covenantSurroundings: {
     label: "arm5e.sheet.covenantSurroundings"
   },
-  other: {
-    label: "arm5e.sheet.other"
-  }
 };
 
 ARM5E.character.fatigueLevels = {

--- a/templates/item/item-flaw-sheet.html
+++ b/templates/item/item-flaw-sheet.html
@@ -9,7 +9,7 @@
                     <label for="data.type.value" class="header-label">{{localize data.type.label}}</label>
                     <select name="data.type.value" data-type="String">
                         {{#select data.type.value}}
-                            {{#each metadata.character.flawTypes as |type key|}}
+                            {{#each metadata.virtueFlawTypes.available as |type key|}}
                                 <option value="{{key}}">{{localize label}}</option>
                             {{/each}} {{/select}}
                     </select>

--- a/templates/item/item-virtue-sheet.html
+++ b/templates/item/item-virtue-sheet.html
@@ -8,7 +8,7 @@
         <div class="resource">
           <label for="data.type.value" class="header-label">{{localize data.type.label}}</label>
           <select name="data.type.value" data-type="String">
-            {{#select data.type.value}} {{#each metadata.character.flawTypes as |type key|}}
+            {{#select data.type.value}} {{#each metadata.virtueFlawTypes.available as |type key|}}
             <option value="{{key}}">{{localize label}}</option>
             {{/each}} {{/select}}
           </select>


### PR DESCRIPTION
Disable edition of automatically created active effect with a new "noEdit" flag. I used a new flag to allow it to be re-used for future hard-coded effects if needed.

Limit selection of virtue/flaw types when they are owned by an actor, to the types available to this actor type.