### PR TITLE
fix laboratory quality synchronization between magus and laboratory

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -219,7 +219,7 @@ export class ArM5eActorSheet extends ActorSheet {
         if (context.data.sanctum.linked) {
           let lab = game.actors.get(context.data.sanctum.actorId);
           if (lab) {
-            context.data.labtotal.quality = lab.data.data.generalQuality.value;
+            context.data.labtotal.quality = lab.data.data.generalQuality.total;
           }
         } else {
           if (context.data.labtotal.quality === undefined) {


### PR DESCRIPTION
Use the calculated total to synchronize with the laboratory General Quality in the Magus sheet.

I checked the other laboratory value and did not find any similar issue.