### PR TITLE
Allow power drop on entity NPC

### DIFF
--- a/module/actor/actor-npc-sheet.js
+++ b/module/actor/actor-npc-sheet.js
@@ -88,6 +88,12 @@ export class ArM5eNPCActorSheet extends ArM5eActorSheet {
           default:
             return true;
         }
+        
+      case "power":
+        if (this.actor.data.data.charType.value === "entity")
+          return true;
+        else 
+          return false;
       case "weapon":
       case "armor":
       case "spell":

--- a/module/arm5e.js
+++ b/module/arm5e.js
@@ -417,7 +417,7 @@ async function onDropActorSheetData(actor, sheet, data) {
     if (sheet.isItemDropAllowed(item.data)) {
       return true;
     } else {
-      console.log("Prevented invalid item drop");
+      log(true, "Prevented invalid item drop ", item.data, " on actor ", actor)
       return false;
     }
   } else if (data.type == "Actor") {


### PR DESCRIPTION
Allow powers to be dropped on NPC character sheet if they are an "Entity" npc.

They can currently only be created on the sheet but not transferred