### PR TITLE
1.4.5 guorna the fetid

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.4.7
+
+### Bug fixes
+
+- Fixed source quality of teaching activity (+3 instead of +6)
+
 ## 1.4.6
 
 ### Bug fixes

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 ## 1.4.7
 
+### Features
+
+- temporary removal of max XP per progress item in adventuring activities (until proper activity type is implemented (V10))
+
 ### Bug fixes
 
 - Fixed source quality of teaching activity (+3 instead of +6)

--- a/module/helpers/long-term-activities.js
+++ b/module/helpers/long-term-activities.js
@@ -397,7 +397,7 @@ export function validTeaching(context, actor, item) {
   } else if (abilitiesArr.length + artsArr.length + spellsArr.length == 0) {
     context.data.applyPossible = "disabled";
   }
-  context.data.baseQuality = 6 + itemData.data.teacher.teaching + itemData.data.teacher.com;
+  context.data.baseQuality = 3 + itemData.data.teacher.teaching + itemData.data.teacher.com;
   if (itemData.data.teacher.applySpec) {
     context.data.baseQuality++;
   }

--- a/module/helpers/long-term-activities.js
+++ b/module/helpers/long-term-activities.js
@@ -205,13 +205,13 @@ export function validAdventuring(context, actor, item) {
 
   let abilitiesArr = Object.values(itemData.data.progress.abilities);
   checkForDuplicates("abilities", context, abilitiesArr);
-  context.data.totalXp.abilities = checkMaxXpPerItem(context, abilitiesArr, 5);
+  context.data.totalXp.abilities = checkMaxXpPerItem(context, abilitiesArr, 1000);
 
-  context.data.totalXp.arts += checkArtProgressItems(context, itemData, 5);
+  context.data.totalXp.arts += checkArtProgressItems(context, itemData, 1000);
 
   let spellsArr = Object.values(itemData.data.progress.spells);
   checkForDuplicates("spells", context, spellsArr);
-  context.data.totalXp.spells = checkMaxXpPerItem(context, spellsArr, 5);
+  context.data.totalXp.spells = checkMaxXpPerItem(context, spellsArr, 1000);
 
   if (
     context.data.totalXp.abilities + context.data.totalXp.arts + context.data.totalXp.spells !=

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -243,7 +243,7 @@ export class ArM5eItem extends Item {
               break;
             }
             case "teaching": {
-              systemData.baseQuality = systemData.teacher.teaching + systemData.teacher.com + 6;
+              systemData.baseQuality = systemData.teacher.teaching + systemData.teacher.com + 3;
               if (systemData.teacher.applySpec) {
                 systemData.baseQuality++;
               }

--- a/system.json
+++ b/system.json
@@ -2,10 +2,9 @@
   "name": "arm5e",
   "title": "Ars Magica 5th Edition, Development version",
   "description": "Ars Magica 5e for Foundry VTT, BETA",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
-  "templateVersion": 3,
   "authors": [
     { "name": "xzotl", "contribution": "Dev and official maintainer" },
     { "name": "ialbiol", "contribution": "Dev" },


### PR DESCRIPTION
temporary removal of max XP per progress item in adventuring activities (until proper activity type is implemented (V10))

### Bug fixes

- Fixed source quality of teaching activity (+3 instead of +6)