### PR TITLE
Lab specialties + fixes

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -17,6 +17,16 @@ Update your Foundry VTT version to at least 0.8.9.
 Unless you have edited the system, remove the old "arm5e" folder from the systems folder (Found in the Foundry Data folder)
 Unzip, rename folder to "arm5e" and copy to systems folder.
 
+## System update
+
+### I updated the system and got a bunch of errors when loading my world. Some actors are now missing!
+
+This is expected if your actors own some "invalid" items.
+A migration should have followed immediately fixing the problems. However, due to a v10 limitation, the actors won't reappear until a refresh.
+If you still have missing actors after the reload, go to bugs channel and we will solve that.
+The important thing to know: no data is lost. Your documents are just put in quarantine until fixed.
+Note: I put invalid in double quotes, because it may simply due to a planned change of the datamodel (eg: a spell could only have one requisite, now it can have any number of them). This is unfortunate but it cannot be helped until V11 (tbc)
+
 ## Compendium content
 
 ### Why are the description of the abilities, virtues, flaws and spells empty?

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thanks to various contributors at https://game-icons.net for some default icons
 
 ![Latest Release Download Count](https://img.shields.io/github/downloads/Xzotl42/arm5e/latest/arm5e.zip)
 
-![Release 2.0.3.14 Download Count](https://img.shields.io/github/downloads/Xzotl42/arm5e/v2.0.3.12/arm5e.zip)
+![Release 2.0.3.14 Download Count](https://img.shields.io/github/downloads/Xzotl42/arm5e/v2.0.3.14/arm5e.zip)
 
 ![Release 1.4.8 Download Count (V9)](https://img.shields.io/github/downloads/Xzotl42/arm5e/v1.4.8/arm5e.zip)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,15 +1,23 @@
-## 2.0.4.18, Kentigern, the apprentice
+## 2.0.4.19, Kentigern, the apprentice
 
 ### Features & changes
 
 - Possibility to study directly from spell lab texts or spell books if in the library of a character or an occupied lab.
 - Preparation for lab diary entries to track their use (owned diary entries may raise an error and need a reload). Every entry can have a list of document ids to remove at rollback.
 - Improved lab text layout
+- Lab specialties are taken into account for the lab total.
+- Activity in the lab will generate a log entry in it so occupation can be tracked.
+- Rollbacking a lab activity will destroy it and its associated items (ie: lab log entry)
+- New laboratory specialties as active effects
+- [technical] new type of field: NullableDocumentIdField
+- Natural weapons are now available on the beast sheet
 
 ### Bug fixes
 
 - Link between Actors is now done at data preparation
 - Fixed error when dropping a lab text on a dedicated book topic
+- Only non zero modifiers are displayed in the lab total details
+- Migration fix for Datamodel error in diaryEntries (system.progress.art.key undefined)
 
 ## 2.0.4.16, Kentigern, the novice
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -114,6 +114,7 @@
   "arm5e.sheet.magicalEffects": "Spontaneous magical effects",
   "arm5e.sheet.spontaneousMagic": "Spontaneous magic",
   "arm5e.sheet.weapons": "Weapons",
+  "arm5e.sheet.naturalweapons": "Natural weapons",
   "arm5e.sheet.armor": "Armor",
   "arm5e.sheet.items": "Items",
   "arm5e.sheet.book": "Book",
@@ -774,7 +775,6 @@
   "arm5e.lab.enchantment.item.size.large-eg": "Large (staff, shield, cloak, skeleton)",
   "arm5e.lab.enchantment.item.size.huge-eg": "Huge (boat, wagon, human body, small room)",
 
-  "arm5e.lab.activity.magicTheory": "Vis study",
   "arm5e.lab.activity.spellLearning": "Spell learning",
   "arm5e.lab.activity.inventSpell": "Invent spell",
   "arm5e.lab.activity.visExtraction": "Vis extraction",
@@ -787,6 +787,15 @@
   "arm5e.lab.bonus.labQuality": "Lab quality",
   "arm5e.lab.bonus.activity": "Activity bonus",
   "arm5e.lab.bonus.apprentice": "Apprentice",
+  "arm5e.lab.bonus.specialties": "Specialties",
+
+  "arm5e.lab.specialty.experimentation": "Experimentation",
+  "arm5e.lab.specialty.familiar": "Familiar",
+  "arm5e.lab.specialty.items": "Items",
+  "arm5e.lab.specialty.longevityRituals": "Longevity rituals",
+  "arm5e.lab.specialty.spells": "Spells",
+  "arm5e.lab.specialty.texts": "Texts",
+  "arm5e.lab.specialty.visExtraction": "Vis extraction",
 
   "arm5.sheet.bonus.activeEffects": "Effects bonuses",
   "arm5e.sheet.action.rest": "Rest",
@@ -1059,6 +1068,7 @@
   "arm5e.activity.title.spellLearning": "Learned a spell",
   "arm5e.activity.title.inventSpell": "Invented a spell",
   "arm5e.activity.drop.teacher": "Drop an actor here to act as a teacher/trainer.",
+  "arm5e.activity.title.labinuse": "Laboratory in use ({activity}) by {user}.",
 
   "arm5e.activity.newSpell": "New spell learned",
   "arm5e.activity.descItem": "{item} : {xp} xp(s) increase",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -58,6 +58,14 @@ export class ArM5ePCActor extends Actor {
         this.system.specialty[key] = { bonus: 0 };
       }
 
+      this.system.specialty["experimentation"] = { bonus: 0 };
+      this.system.specialty["familiar"] = { bonus: 0 };
+      this.system.specialty["items"] = { bonus: 0 };
+      this.system.specialty["longevityRituals"] = { bonus: 0 };
+      this.system.specialty["spells"] = { bonus: 0 };
+      this.system.specialty["texts"] = { bonus: 0 };
+      this.system.specialty["visExtraction"] = { bonus: 0 };
+
       return;
     }
     let datetime = game.settings.get("arm5e", "currentDate");

--- a/module/config.js
+++ b/module/config.js
@@ -2238,7 +2238,7 @@ ARM5E.activities.generic = {
     secondaryFilter: null
   },
   learnSpell: {
-    label: "arm5e.activity.spellLearning",
+    label: "arm5e.lab.activity.spellLearning",
     display: {
       tab: true,
       progress: true,
@@ -2255,7 +2255,7 @@ ARM5E.activities.generic = {
     secondaryFilter: null
   },
   inventSpell: {
-    label: "arm5e.activity.inventSpell",
+    label: "arm5e.lab.activity.inventSpell",
     display: {
       tab: true,
       progress: true,

--- a/module/constants/activeEffectsTypes.js
+++ b/module/constants/activeEffectsTypes.js
@@ -1605,9 +1605,51 @@ export default {
   },
   labSpecialty: {
     category: "laboratory",
-    type: "laboratory",
+    type: "laboratorySpec",
     label: "arm5e.sheet.activeEffect.types.laboratorySpec",
     subtypes: {
+      texts: {
+        label: "arm5e.lab.specialty.texts",
+        key: "system.specialty.texts.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      spells: {
+        label: "arm5e.lab.specialty.spells",
+        key: "system.specialty.spells.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      experimentation: {
+        label: "arm5e.lab.specialty.experimentation",
+        key: "system.specialty.experimentation.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      familiar: {
+        label: "arm5e.lab.specialty.familiar",
+        key: "system.specialty.familiar.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      items: {
+        label: "arm5e.lab.specialty.items",
+        key: "system.specialty.items.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      longevityRituals: {
+        label: "arm5e.lab.specialty.longevityRituals",
+        key: "system.specialty.longevityRituals.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      visExtraction: {
+        label: "arm5e.lab.specialty.visExtraction",
+        key: "system.specialty.visExtraction.bonus",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
       cr: {
         label: "Creo",
         key: "system.specialty.cr.bonus",
@@ -1694,12 +1736,6 @@ export default {
       },
       vi: {
         label: "Vim",
-        key: "system.specialty.vi.bonus",
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
-        default: 1
-      },
-      gen: {
-        label: "arm5e.generic.custom",
         key: "system.specialty.vi.bonus",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 1

--- a/module/helpers/active-effects.js
+++ b/module/helpers/active-effects.js
@@ -129,6 +129,25 @@ export default class ArM5eActiveEffect extends ActiveEffect {
     return activeEffects;
   }
 
+  static findAllActiveEffectsWithTypeFiltered(effects, type) {
+    const activeEffects = [];
+    let filtered = effects.filter(e => !e.disabled && e.getFlag("arm5e", "type").includes(type));
+    for (let e of filtered) {
+      e._getSourceName(); // Trigger a lookup for the source name
+      let idx = 0;
+      let filteredChanges = [];
+      for (let ch of e.changes) {
+        if (e.flags.arm5e.type[idx] === type) {
+          log(false, ch);
+          filteredChanges.push(ch);
+        }
+      }
+      e.changes = filteredChanges;
+      activeEffects.push(e);
+    }
+    return activeEffects;
+  }
+
   static findAllActiveEffectsWithSubtype(effects, subtype) {
     let res = [];
     for (let e of effects) {

--- a/module/item/item-diary-sheet.js
+++ b/module/item/item-diary-sheet.js
@@ -752,6 +752,15 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
     const actor = this.actor;
     let updateData = [];
     switch (this.item.system.activity) {
+      case "learnSpell":
+      case "inventSpell":
+        let toDelete = this.item.system.externalIds[0];
+        if (game.actors.has(toDelete.actorId)) {
+          let lab = game.actors.get(toDelete.actorId);
+          if (lab.items.has(toDelete.itemId)) {
+            await lab.deleteEmbeddedDocuments("Item", [toDelete.itemId], {});
+          }
+        }
       case "adventuring":
       case "exposure":
       case "practice":
@@ -761,8 +770,7 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
       case "hermeticApp":
       case "childhood":
       case "laterLife":
-      case "laterLifeMagi":
-      case "learnSpell": {
+      case "laterLifeMagi": {
         for (const ab of Object.values(this.item.system.progress.abilities)) {
           // check that ability still exists
           let ability = this.actor.items.get(ab.id);
@@ -820,7 +828,9 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
 
         await this.actor.update(actorUpdate, { render: true });
         await this.actor.updateEmbeddedDocuments("Item", updateData, { render: true });
-        if (this.item.system.activity === "reading") {
+
+        if (["reading", "inventSpell", "learnSpell"].includes(this.item.system.activity)) {
+          // delete the diary entry
           await this.actor.deleteEmbeddedDocuments("Item", [this.item.id], {});
           return;
         }

--- a/module/schemas/commonSchemas.js
+++ b/module/schemas/commonSchemas.js
@@ -2,6 +2,8 @@ import { ARM5E } from "../config.js";
 
 const fields = foundry.data.fields;
 
+const validators = foundry.data.validators;
+
 export class NullableEmbeddedDataField extends fields.EmbeddedDataField {
   /**
    * @param {typeof DataModel} model          The class of DataModel which should be embedded in this field
@@ -16,6 +18,32 @@ export class NullableEmbeddedDataField extends fields.EmbeddedDataField {
       return super.toObject(value);
     }
     return null;
+  }
+}
+
+export class NullableDocumentIdField extends fields.DocumentIdField {
+  /** @inheritdoc */
+  static get _defaults() {
+    return mergeObject(super._defaults, {
+      required: false,
+      blank: false,
+      nullable: true,
+      initial: null,
+      readonly: true,
+      validationError: "is not a valid Document ID string"
+    });
+  }
+
+  /** @override */
+  _cast(value) {
+    if (value instanceof foundry.abstract.Document) return value._id;
+    else return String(value);
+  }
+
+  /** @override */
+  _validateType(value) {
+    if (!validators.isValidId(value) && value !== null)
+      throw new Error("must be a valid 16-character alphanumeric ID or null");
   }
 }
 

--- a/module/schemas/diarySchema.js
+++ b/module/schemas/diarySchema.js
@@ -4,6 +4,7 @@ import {
   characteristicField,
   convertToNumber,
   hermeticForm,
+  NullableDocumentIdField,
   SeasonField,
   XpField
 } from "./commonSchemas.js";
@@ -93,10 +94,21 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
           step: 1
         })
       }),
-      externalIds: new fields.ArrayField(new fields.DocumentIdField(), {
-        required: false,
-        initial: []
-      }),
+      externalIds: new fields.ArrayField(
+        new fields.SchemaField({
+          actorId: new NullableDocumentIdField(),
+          itemId: new NullableDocumentIdField(),
+          flags: new fields.NumberField({
+            required: false,
+            nullable: false,
+            integer: true,
+            min: 0,
+            initial: 0,
+            step: 1
+          })
+        }),
+        { required: false, initial: [] }
+      ),
       progress: new fields.SchemaField({
         abilities: new fields.ArrayField(
           new fields.SchemaField({
@@ -323,7 +335,7 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
         updateNeeded = true;
       }
       for (let a of prog.arts) {
-        if (a.key === "") {
+        if (a.key === "" || a.key === undefined) {
           a.key = "cr";
           updateNeeded = true;
         }

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "name": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT",
-  "version": "2.0.4.18",
+  "version": "2.0.4.19",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",

--- a/templates/actor/actor-beast-sheet.html
+++ b/templates/actor/actor-beast-sheet.html
@@ -97,6 +97,7 @@
         <div class="tab" data-group="desc-secondary" data-tab="wounds">
           {{> "systems/arm5e/templates/actor/parts/actor-fatigue.html" }}
           {{> "systems/arm5e/templates/actor/parts/actor-combat.html" }}
+          {{> "systems/arm5e/templates/actor/parts/actor-weapons.html" }}
         </div>
       </section>
     </div>

--- a/templates/actor/parts/actor-weapons.html
+++ b/templates/actor/parts/actor-weapons.html
@@ -2,7 +2,11 @@
     <li class="item flexrow item-header">
         <div class="item-image"></div>
         <div class="item-name">
-            {{localize "arm5e.sheet.weapons"}}
+            {{#if (eq actor.type "beast")}}
+                {{localize "arm5e.sheet.naturalweapons"}}
+            {{else}}
+                {{localize "arm5e.sheet.weapons"}}
+            {{/if}}
         </div>
         <div class="item-controls">
             <a class="item-control item-create"


### PR DESCRIPTION
- Lab specialties are taken into account for the lab total.
- Activity in the lab will generate a log entry in it so occupation can be tracked.
- Rollbacking a lab activity will destroy it and its associated items (ie: lab log entry)
- New laboratory specialties as active effects
- [technical] new type of field: NullableDocumentIdField
- Natural weapons are now available on the beast sheet

- Only non zero modifiers are displayed in the lab total details
- Migration fix for Datamodel error in diaryEntries (system.progress.art.key undefined)