### PR TITLE
Small improvements and fixes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-## 2.0.5.7, Lexora, the apprentice
+## 2.0.5.8, Lexora, the apprentice
 
 ### Features & changes
 
@@ -10,6 +10,10 @@
 - Personality traits are now Items wit XPs
 - Common law and Canon and Civic law have been merged into a new generic ability: Law
 - New macros for quick access to combat and vitals stats of selected token
+- New design for journal links
+- Diary entries are now also sorted in inverted alphabetical order of date field before title.
+- Changing a reader's Actor sheet will reflect in the scriptorium.
+- Longevity ritual bonus moved next to decrepitude stats and now available to all type of characters.
 
 ### Bug fixes
 
@@ -20,6 +24,9 @@
 - Fixed migration bug of reputations and personality traits for invalid actors
 - "Equipped" is now properly spelled
 - Fatigue overflow is now working properly
+- Rework of DiaryEntry sheet:
+  - Active effects bonus is not displayed twice
+  - Added max level to each progress item to prevent overflow by active effect.
 - Migration
   - Weapon.load not a number
 

--- a/css/arm5e.css
+++ b/css/arm5e.css
@@ -247,14 +247,40 @@ span.player-name {
   font-family: bookAntiqua;
 }
 
-.journal-entry-page a.content-link {
-  background: rgba(0, 0, 0, 0.1);
-  padding: 1px 4px;
-  border: 1px solid var(--color-border-dark-tertiary);
+.arm5e .journal-entry-page a.content-link {
   border-radius: 2px;
   white-space: nowrap;
   word-break: break-all;
+  text-decoration: underline;
+  color: #6e98db;
+  border-bottom: 1px dotted blue;
+  border: none;
+  background-color: transparent;
+  background-image: none;
+  padding: 0px;
 }
+
+.arm5e .journal-entry-page a.content-link.broken {
+  border-radius: 2px;
+  white-space: nowrap;
+  word-break: break-all;
+  text-decoration: underline;
+  border-bottom: 1px dotted blue;
+  border: none;
+  background-color: transparent;
+  background-image: none;
+  padding: 0px;
+  color: #f05959;
+}
+
+.arm5e a.content-link i.fa-file-lines {
+  display: none;
+}
+
+.arm5e a.content-link i.fa-book-open {
+  display: none;
+}
+
 .scriptorium.resource {
   /* width: 220px; */
   padding-top: 5px;

--- a/lang/es.json
+++ b/lang/es.json
@@ -814,7 +814,6 @@
   "arm5e.messages.noWound": "No se ha causado ninguna herida",
   "arm5e.messages.woundResult": "Recibe una herida {typeWound}",
   "arm5e.messages.fatigueLost": "Pierde {num} nivel(es) de Fatiga",
-  "arm5e.messages.noWound": "No se sufren heridas",
   "arm5e.messages.applyDamage": "Aplicar daño",
   "arm5e.messages.useConf": "Usar punto de Confianza",
   "arm5e.messages.die.exploding": "¡El dado estrés explota!",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -526,7 +526,7 @@ export class ArM5eActorSheet extends ActorSheet {
           activity.type = game.i18n.localize(
             CONFIG.ARM5E.activities.generic[entry.system.activity].label
           );
-          activity.date = entry.system.date;
+          activity.date = date.date;
 
           activity._id = entry._id;
           if (!activitiesMap.has(date.year)) {

--- a/module/config.js
+++ b/module/config.js
@@ -164,60 +164,46 @@ ARM5E.character.characteristics = {
 };
 ARM5E.character.houses = {
   "n-a": {
-    label: "N/A",
-    dtype: "String"
+    label: "N/A"
   },
   bjo: {
-    label: "Bjornaer",
-    dtype: "String"
+    label: "Bjornaer"
   },
   bon: {
-    label: "Bonisagus",
-    dtype: "String"
+    label: "Bonisagus"
   },
   cri: {
-    label: "Criamon",
-    dtype: "String"
+    label: "Criamon"
   },
   exm: {
-    label: "Ex Miscellanea",
-    dtype: "String"
+    label: "Ex Miscellanea"
   },
   fla: {
-    label: "Flambeau",
-    dtype: "String"
+    label: "Flambeau"
   },
   gen: {
-    label: "Generic Magus",
-    dtype: "String"
+    label: "Generic Magus"
   },
   gue: {
-    label: "Guernicus",
-    dtype: "String"
+    label: "Guernicus"
   },
   jer: {
-    label: "Jerbiton",
-    dtype: "String"
+    label: "Jerbiton"
   },
   mer: {
-    label: "Mercere",
-    dtype: "String"
+    label: "Mercere"
   },
   mta: {
-    label: "Merinita",
-    dtype: "String"
+    label: "Merinita"
   },
   tre: {
-    label: "Tremere",
-    dtype: "String"
+    label: "Tremere"
   },
   tyt: {
-    label: "Tytalus",
-    dtype: "String"
+    label: "Tytalus"
   },
   ver: {
-    label: "Verditius",
-    dtype: "String"
+    label: "Verditius"
   }
 };
 ARM5E.character.description = {

--- a/module/item/item-book-sheet.js
+++ b/module/item/item-book-sheet.js
@@ -131,7 +131,6 @@ export class ArM5eBookSheet extends ArM5eItemSheet {
     if (topic.category == "labText") {
       return;
     }
-
     let formData = {
       seasons: CONFIG.ARM5E.seasons,
       abilityKeysList: CONFIG.ARM5E.LOCALIZED_ABILITIES,
@@ -144,22 +143,23 @@ export class ArM5eBookSheet extends ArM5eItemSheet {
       reading: {
         reader: { id: null },
         book: {
-          id: item.id,
-          title: item.name,
-          language: item.system.language,
-          author: item.system.author,
-          topics: item.system.topics,
-          topicIndex: dataset.index
+          uuid: item.uuid,
+          id: item._id,
+          name: item.name,
+          system: item.system.toObject()
         }
       }
     };
-
+    formData.reading.book.system.topicIndex = this.item.getFlag("arm5e", "currentBookTopic");
     if (item.isOwned && item.actor._isCharacter()) {
       formData.reading.reader.id = item.actor.id;
     }
 
     const scriptorium = new Scriptorium(formData, {}); // data, options
     const res = await scriptorium.render(true);
+    if (formData.reading.reader.id) {
+      item.actor.apps[scriptorium.appId] = scriptorium;
+    }
   }
 
   async _changeCurrentTopic(item, event, offset) {

--- a/module/item/item-diary-sheet.js
+++ b/module/item/item-diary-sheet.js
@@ -1213,6 +1213,11 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
       expanded.system.progress.newSpells = mergeObject(source.system.progress.newSpells, newSpells);
     }
 
+    const dates = expanded?.system?.dates;
+    if (dates) {
+      expanded.system.dates = mergeObject(source.system.dates, dates);
+    }
+
     log(false, `Update object: ${JSON.stringify(expanded)}`);
     await this.object.update(expanded);
   }

--- a/module/schemas/bookSchema.js
+++ b/module/schemas/bookSchema.js
@@ -88,6 +88,7 @@ export class BookSchema extends foundry.abstract.DataModel {
     // console.log(`MigrateData book: ${JSON.stringify(data)}`);
 
     if (data.topics && data.topics.length !== 0) {
+      data.topic = null;
       return data;
     }
     if (data.topic) {

--- a/module/schemas/diarySchema.js
+++ b/module/schemas/diarySchema.js
@@ -28,15 +28,15 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
             initial: 1200,
             step: 1
           }),
+          date: new fields.StringField({
+            required: false,
+            blank: true,
+            initial: ""
+          }),
           applied: new fields.BooleanField({ required: false, initial: false })
         }),
         { required: false, initial: [] }
       ),
-      date: new fields.StringField({
-        required: false,
-        blank: true,
-        initial: ""
-      }),
       duration: new fields.NumberField({
         required: false,
         nullable: false,
@@ -143,6 +143,14 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
                 initial: 2,
                 step: 1
               }),
+              maxLevel: new fields.NumberField({
+                required: false,
+                nullable: false,
+                integer: true,
+                min: 0,
+                initial: 0,
+                step: 1
+              }),
               xp: XpField()
             }),
             { required: false, initial: [] }
@@ -156,6 +164,14 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
                 integer: true,
                 min: 0,
                 initial: 5,
+                step: 1
+              }),
+              maxLevel: new fields.NumberField({
+                required: false,
+                nullable: false,
+                integer: true,
+                min: 0,
+                initial: 0,
                 step: 1
               }),
               xp: XpField()
@@ -177,6 +193,14 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
                 integer: true,
                 min: 0,
                 initial: 2,
+                step: 1
+              }),
+              maxLevel: new fields.NumberField({
+                required: false,
+                nullable: false,
+                integer: true,
+                min: 0,
+                initial: 0,
                 step: 1
               }),
               xp: XpField()
@@ -218,12 +242,12 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
     if (itemData.system) {
       if (itemData.system.dates == undefined) {
         itemData.system.dates = [
-          { year: currentDate.year, season: currentDate.season, applied: false }
+          { year: currentDate.year, season: currentDate.season, date: "", applied: false }
         ];
       }
     } else {
       itemData.system = {
-        dates: [{ year: currentDate.year, season: currentDate.season, applied: false }]
+        dates: [{ year: currentDate.year, season: currentDate.season, date: "", applied: false }]
       };
     }
   }
@@ -300,18 +324,42 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
 
       updateData["system.-=applied"] = null;
       updateData["system.-=year"] = null;
+      updateData["system.-=date"] = null;
       updateData["system.-=season"] = null;
       updateData["system.dates"] = [
-        { year: theYear, season: theSeason, applied: itemData.system.applied }
+        {
+          year: theYear,
+          season: theSeason,
+          date: itemData.system.date,
+          applied: itemData.system.applied
+        }
       ];
+    } else if (itemData.system.date != undefined) {
+      for (let d of itemData.system.dates) {
+        d.date = itemData.system.date;
+      }
+      updateData["system.-=date"] = null;
+      updateData["system.dates"] = itemData.system.dates;
     } else if (itemData.system.dates == []) {
       updateData["system.dates"] = [
         {
           year: Number(currentDate.year),
           season: currentDate.season,
+          date: itemData.system.date ?? "",
           applied: itemData.system.applied ?? false
         }
       ];
+    } else {
+      let update = false;
+      for (let d of itemData.system.dates) {
+        if (d.date === undefined) {
+          d.date = "";
+          update = true;
+        }
+      }
+      if (update) {
+        updateData["system.dates"] = itemData.system.dates;
+      }
     }
     // if (itemData.system.applied !== undefined) {
     //   // if applied exists, the array should be of length 1

--- a/module/tools.js
+++ b/module/tools.js
@@ -177,18 +177,24 @@ export function compareBooks(b1, b2) {
 
 const seasonOrder = { spring: 0, summer: 1, autumn: 2, winter: 3 };
 
+// TODO multi seasons activities
 export function compareDiaryEntries(e1, e2) {
-  if (e1.system.year < e2.system.year) {
+  if (e1.system.dates[0].year < e2.system.dates[0].year) {
     return 1;
-  } else if (e1.system.year > e2.system.year) {
+  } else if (e1.system.dates[0].year > e2.system.dates[0].year) {
     return -1;
   } else {
-    if (seasonOrder[e1.system.season] < seasonOrder[e2.system.season]) {
+    if (seasonOrder[e1.system.dates[0].season] < seasonOrder[e2.system.dates[0].season]) {
       return 1;
-    } else if (seasonOrder[e1.system.season] > seasonOrder[e2.system.season]) {
+    } else if (seasonOrder[e1.system.dates[0].season] > seasonOrder[e2.system.dates[0].season]) {
       return -1;
     } else {
-      return e1.name.localeCompare(e2.name);
+      let cmp = -e1.system.dates[0].date.localeCompare(e2.system.dates[0].date);
+      if (cmp) {
+        return cmp;
+      } else {
+        return e1.name.localeCompare(e2.name);
+      }
     }
   }
 }

--- a/module/ui/ars-layer.js
+++ b/module/ui/ars-layer.js
@@ -82,26 +82,29 @@ export class ArsLayer extends InteractionLayer {
       reading: {
         reader: { id: null },
         book: {
+          uuid: null,
           id: null,
-          title: game.i18n.localize("arm5e.activity.book.title"),
-          language: game.i18n.localize("arm5e.skill.commonCases.latin"),
-          author: game.i18n.localize("arm5e.generic.unknown"),
-          topics: [
-            {
-              category: "ability",
-              type: "Summa",
-              author: game.i18n.localize("arm5e.generic.unknown"),
-              quality: 1,
-              level: 1,
-              key: "",
-              option: "",
-              spellName: "",
-              art: "",
-              spellTech: "cr",
-              spellForm: "an"
-            }
-          ],
-          topicIndex: 0
+          name: game.i18n.localize("arm5e.activity.book.title"),
+          system: {
+            language: game.i18n.localize("arm5e.skill.commonCases.latin"),
+            author: game.i18n.localize("arm5e.generic.unknown"),
+            topics: [
+              {
+                category: "ability",
+                type: "Summa",
+                author: game.i18n.localize("arm5e.generic.unknown"),
+                quality: 1,
+                level: 1,
+                key: "",
+                option: "",
+                spellName: "",
+                art: "",
+                spellTech: "cr",
+                spellForm: "an"
+              }
+            ],
+            topicIndex: 0
+          }
         }
       }
     };

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "name": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT",
-  "version": "2.0.5.7",
+  "version": "2.0.5.8",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",

--- a/template.json
+++ b/template.json
@@ -575,7 +575,7 @@
         "label": "Char. Type"
       },
       "house": {
-        "value": "",
+        "value": "n-a",
         "label": "House"
       },
       "dom-mag": {

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -245,6 +245,7 @@
         <section class="lab-body">
           <div class="tab" data-group="lab-secondary" data-tab="lab">
             {{> "systems/arm5e/templates/actor/parts/actor-laboratory.html" }}
+            {{> "systems/arm5e/templates/actor/parts/actor-familiar.html" }}
           </div>
           <div class="tab" data-group="lab-secondary" data-tab="lab-total">
             {{> "systems/arm5e/templates/actor/parts/actor-laboratoryTotals.html" show="laboratory" }}

--- a/templates/actor/actor-pc-sheet.html
+++ b/templates/actor/actor-pc-sheet.html
@@ -236,6 +236,7 @@
         <section class="lab-body">
           <div class="tab" data-group="lab-secondary" data-tab="lab">
             {{> "systems/arm5e/templates/actor/parts/actor-laboratory.html" }}
+            {{> "systems/arm5e/templates/actor/parts/actor-familiar.html" }}
           </div>
           <div class="tab" data-group="lab-secondary" data-tab="lab-total">
             {{> "systems/arm5e/templates/actor/parts/actor-laboratoryTotals.html"}}

--- a/templates/actor/parts/actor-description.html
+++ b/templates/actor/parts/actor-description.html
@@ -5,7 +5,7 @@
         <div class="flex-group-left backSection padding12">
           <div class="flexrow marginbot6">
             <label for="system.house.value" class="bold">{{localize "arm5e.sheet.house"}}</label>
-            <span class="width2"><select name="system.house.value" data-type="String" style="width: 100%">
+            <span class="width2"><select name="system.house.value" data-dtype="String" style="width: 100%">
                 {{#select system.house.value}} {{#each config.character.houses as |house key|}}
                     <option value="{{key}}">{{house.label}}</option>
                   {{/each}} {{/select}}
@@ -62,7 +62,7 @@
       <div class="flexrow">
         <label for="system.warping.effects" class="bold">{{localize "arm5e.sheet.effects"}}</label>
       </div>
-      <div class="flex-group-left marginbot6" style="height: 140px">
+      <div class="flex-group-left marginbot6" style="height: 150px">
         {{editor system.warping.effects target="system.warping.effects" button=true owner=owner editable=editable}}
       </div>
     </div>
@@ -92,9 +92,21 @@
       <div class="flexrow">
         <label for="system.decrepitude.effects" class="bold">{{localize "arm5e.sheet.effects"}}</label>
       </div>
-      <div class="flex-group-left marginbot6" style="height: 140px">
+      <div class="flex-group-left marginbot6" style="height: 150px">
         {{editor system.decrepitude.effects target="system.decrepitude.effects" button=true owner=owner
       editable=editable}}
+      </div>
+      <div class="flexrow">
+        <div class="flexrow flex-group-center">
+          <label for="system.laboratory.longevityRitual.labTotal">{{localize "arm5e.sheet.labTotal"}}</label>
+          <input type="number" name="system.laboratory.longevityRitual.labTotal"
+            value="{{system.laboratory.longevityRitual.labTotal }}" data-dtype="Number" />
+        </div>
+        <div class="flexrow flex-group-center">
+          <label for="system.laboratory.longevityRitual.modifier">{{localize "arm5e.sheet.longevityModifier"}}</label>
+          <input type="number" name="system.laboratory.longevityRitual.modifier"
+            value="{{system.laboratory.longevityRitual.modifier }}" data-dtype="Number" />
+        </div>
       </div>
     </div>
   </div>

--- a/templates/actor/parts/actor-laboratory.html
+++ b/templates/actor/parts/actor-laboratory.html
@@ -3,14 +3,6 @@
   <div class="characteristics grid grid-3col">
     <div class="flexrow flex-group-center" style="border: 0px">
       <label class="smallTitle">
-        <a class="link" href="/systems/arm5e/pdf/longevityRitual.pdf" target="_blank">
-          {{localize "arm5e.sheet.longevityRitual"}}
-        </a>
-      </label>
-    </div>
-
-    <div class="flexrow flex-group-center" style="border: 0px">
-      <label class="smallTitle">
         <a class="link" href="/systems/arm5e/pdf/laboratory.pdf" target="_blank">
           {{localize "arm5e.sheet.laboratory"}}
         </a>
@@ -18,10 +10,10 @@
     </div>
   </div>
 
-  <div class="characteristics grid grid-2col">
-    <div>
-      <div class="flexrow flex-group-center" style="border: 0px">
-        <label for="system.sanctum.value">{{localize "arm5e.sheet.sanctum"}}</label>
+  <div class="characteristics flexrow">
+    <div class="flexcol flex03 flex-group-center" style="border: 0px">
+      <label for="system.sanctum.value">{{localize "arm5e.sheet.sanctum"}}</label>
+      <div>
         <input type="text" name="system.sanctum.value" value="{{system.sanctum.value }}" data-dtype="String" />
         {{#if (eq system.sanctum.linked true)}}
           <a class="item-control actor-link flex0" title="Linked to sanctum"
@@ -29,17 +21,6 @@
         {{else}}
           <a title="Not linked to sanctum" class="flex0"><i class="fas fa-unlink fa-sm"></i></a>
         {{/if}}
-      </div>
-      <div class="flexrow flex-group-center" style="border: 0px">
-        <label for="system.laboratory.longevityRitual.labTotal">{{localize "arm5e.sheet.labTotal"}}</label>
-        <input type="number" name="system.laboratory.longevityRitual.labTotal"
-          value="{{system.laboratory.longevityRitual.labTotal }}" data-dtype="Number" />
-      </div>
-
-      <div class="flexrow flex-group-center" style="border: 0px">
-        <label for="system.laboratory.longevityRitual.modifier">{{localize "arm5e.sheet.longevityModifier"}}</label>
-        <input type="number" name="system.laboratory.longevityRitual.modifier"
-          value="{{system.laboratory.longevityRitual.modifier }}" data-dtype="Number" />
       </div>
     </div>
     <div class="flexcol">
@@ -52,8 +33,4 @@
       </div>
     </div>
   </div>
-
-
 </div>
-
-{{> "systems/arm5e/templates/actor/parts/actor-familiar.html" }}

--- a/templates/generic/scriptorium.html
+++ b/templates/generic/scriptorium.html
@@ -50,7 +50,7 @@
     <div class="tab" data-group="primary" data-tab="reading">
       <div class="flexrow marginsides32">
         <div class="scriptorium backSection padding10 resource flexcol">
-          {{#if (eq reading.book.id null)}}
+          {{#if (eq reading.book.uuid null)}}
             <div class="resource drop-box drop-book" data-drop="book">
               <label>{{localize "arm5e.scriptorium.msg.dropBook"}}</label>
             </div>
@@ -65,27 +65,27 @@
           {{/if}}
 
           <label class="header-label">{{localize "arm5e.activity.book.title"}}</label>
-          <input type="text" name="reading.book.title" value="{{reading.book.title}}" data-dtype="String"
+          <input type="text" name="reading.book.name" value="{{reading.book.name}}" data-dtype="String"
             {{ui.canEditBook}}>
           <label class="header-label">{{localize "arm5e.sheet.authorship.language"}}</label>
-          <input type="text" name="reading.book.language" value="{{reading.book.language}}" data-dtype="String"
-            {{ui.canEditBook}}>
+          <input type="text" name="reading.book.system.language" value="{{reading.book.system.language}}"
+            data-dtype="String" {{ui.canEditBook}}>
           <label class="header-label">{{localize "arm5e.sheet.authorship.author"}}</label>
-          <input type="text" name="reading.book.author" value="{{reading.book.author}}" data-dtype="String"
-            {{ui.canEditBook}}>
+          <input type="text" name="reading.book.system.author" value="{{reading.book.system.author}}"
+            data-dtype="String" {{ui.canEditBook}}>
           <div class="resource flexcol flexrow">
             <label class="header-label">{{localize "arm5e.sheet.bookTopic"}}</label>
-            <select class="book-topic" name="reading.book.topics.{{topicIndex}}.category" data-index="{{topicIndex}}"
-              data-dtype="String" {{ui.disabledBook}}>
+            <select class="book-topic" name="reading.book.system.topics.{{topicIndex}}.category"
+              data-index="{{topicIndex}}" data-dtype="String" {{ui.disabledBook}}>
               {{#select reading.book.currentTopic.category}}
                 {{#each bookTopics as |book key|}}
                   <option value="{{key}}">{{localize book}}</option>
                 {{/each}}
               {{/select}}
             </select>
-            <label for="reading.book.{{topicIndex}}.type"
+            <label for="reading.book.system.topics.{{topicIndex}}.type"
               class="header-label">{{localize "arm5e.sheet.bookType"}}</label>
-            <select name="reading.book.topics.{{topicIndex}}.type" data-type="String" data-index="{{topicIndex}}"
+            <select name="reading.book.system.topics.{{topicIndex}}.type" data-type="String" data-index="{{topicIndex}}"
               {{ui.disabledBook}} {{ui.disableType}}>
               {{#select reading.book.currentTopic.type}} {{#each @root.bookTypes }}
                   <option value="{{this}}">{{this}}</option>
@@ -94,9 +94,9 @@
           </div>
           {{#if (eq reading.book.currentTopic.category "art")}}
             <div class="resource" style="width: 220px; padding-top: 5px;">
-              <label for="reading.book.topics.{{topicIndex}}.art"
+              <label for="reading.book.system.topics.{{topicIndex}}.art"
                 class="header-label">{{localize "arm5e.sheet.art"}}</label>
-              <select name="reading.book.topics.{{topicIndex}}.art" data-type="String" {{ui.disabledBook}}>
+              <select name="reading.book.system.topics.{{topicIndex}}.art" data-type="String" {{ui.disabledBook}}>
                 {{#select reading.book.currentTopic.art}} {{#each arts as |art key|}}
                     <option value="{{key}}">{{art.label}}</option>
                   {{/each}} {{/select}}
@@ -105,9 +105,9 @@
           {{/if}}
           {{#if (eq reading.book.currentTopic.category "ability")}}
             <div class="scriptorium resource">
-              <label for="reading.book.topics.{{topicIndex}}.key"
+              <label for="reading.book.system.topics.{{topicIndex}}.key"
                 class="header-label">{{localize "arm5e.sheet.skill.abilityKey"}}</label>
-              <select name="reading.book.topics.{{topicIndex}}.key" data-dtype="String" class="ability-key"
+              <select name="reading.book.system.topics.{{topicIndex}}.key" data-dtype="String" class="ability-key"
                 {{ui.disabledBook}}>
                 {{#select reading.book.currentTopic.key}}
                   {{#each abilityKeysList as |item key|}}
@@ -118,32 +118,32 @@
             </div>
             <div class="scriptorium resource" style="width: 220px; padding-top: 5px;padding-bottom: 15px;">
               {{#if (lookup (lookup abilityKeysList reading.book.currentTopic.key) "option")}}
-                <label for="reading.book.topics.{{topicIndex}}.option"
+                <label for="reading.book.system.topics.{{topicIndex}}.option"
                   class="header-label">{{localize "arm5e.sheet.skill.abilityOption"}}</label>
-                <input type="text" class="ability-option" name="reading.book.topics.{{topicIndex}}.option"
+                <input type="text" class="ability-option" name="reading.book.system.topics.{{topicIndex}}.option"
                   value='{{reading.book.currentTopic.option}}' {{ui.canEditBook}} />
               {{else}}
-                <label for="reading.book.topics.{{topicIndex}}.option" class="header-label"
+                <label for="reading.book.system.topics.{{topicIndex}}.option" class="header-label"
                   style="color: gray">{{localize "arm5e.sheet.skill.abilityOption"}}</label>
-                <input type="text" name="reading.book.topics.{{topicIndex}}.option" data-dtype="String" value=""
+                <input type="text" name="reading.book.system.topics.{{topicIndex}}.option" data-dtype="String" value=""
                   readonly />
               {{/if}}
             </div>
           {{/if}}
           {{#if (eq reading.book.currentTopic.category "mastery")}}
             <div class="scriptorium resource">
-              <label for="reading.book.topics.{{topicIndex}}.spellName"
+              <label for="reading.book.system.topics.{{topicIndex}}.spellName"
                 class="header-label">{{localize "arm5e.sheet.spell"}}</label>
-              <input type="text" name="reading.book.topics.{{topicIndex}}.spellName"
+              <input type="text" name="reading.book.system.topics.{{topicIndex}}.spellName"
                 value='{{reading.book.currentTopic.spellName}}' {{ui.canEditBook}} />
             </div>
             <div class="scriptorium resource">
-              <select name="reading.book.topics.{{topicIndex}}.spellTech" data-type="String" {{ui.disabledBook}}>
+              <select name="reading.book.system.topics.{{topicIndex}}.spellTech" data-type="String" {{ui.disabledBook}}>
                 {{#select reading.book.currentTopic.spellTech}} {{#each techs as |tech key|}}
                     <option value="{{key}}">{{tech.label}}</option>
                   {{/each}} {{/select}}
               </select>
-              <select name="reading.book.topics.{{topicIndex}}.spellForm" data-type="String" {{ui.disabledBook}}>
+              <select name="reading.book.system.topics.{{topicIndex}}.spellForm" data-type="String" {{ui.disabledBook}}>
                 {{#select reading.book.currentTopic.spellForm}} {{#each forms as |form key|}}
                     <option value="{{key}}">{{form.label}}</option>
                   {{/each}} {{/select}}
@@ -153,12 +153,12 @@
           <div class="grid-2col">
             {{#if (eq reading.book.currentTopic.type "Summa")}}
               <label class="header-label">{{localize "arm5e.sheet.level"}}</label>
-              <input type="number" name="reading.book.topics.{{topicIndex}}.level"
+              <input type="number" name="reading.book.system.topics.{{topicIndex}}.level"
                 value='{{reading.book.currentTopic.level}}' data-dtype="Number" style="max-width: 50px;"
                 {{ui.canEditBook}}>
             {{/if}}
             <label class="header-label">{{localize "arm5e.sheet.quality"}}</label>
-            <input type="number" name="reading.book.topics.{{topicIndex}}.quality"
+            <input type="number" name="reading.book.system.topics.{{topicIndex}}.quality"
               value='{{reading.book.currentTopic.quality}}' data-dtype="Number" style="max-width: 50px;"
               {{ui.canEditBook}}>
           </div>

--- a/templates/item/item-diaryEntry-sheet.html
+++ b/templates/item/item-diaryEntry-sheet.html
@@ -26,8 +26,8 @@
       <div class="grid grid-col">
 
         <div class="resource">
-          <label>{{localize "arm5e.sheet.date"}}<input type="text" name="system.date" value="{{system.date}}"
-              data-dtype="String" /></label>
+          <label>{{localize "arm5e.sheet.date"}}<input type="text" name="system.dates.0.date"
+              value="{{system.dates.0.date}}" data-dtype="String" /></label>
           <input type="checkbox" name="system.dates.0.applied" hidden {{checked system.dates.0.applied}}
             data-dtype="Boolean">
         </div>


### PR DESCRIPTION
- New design for journal links
- Diary entries are now also sorted in inverted alphabetical order of date field before title.
- Changing a reader's Actor sheet will reflect in the scriptorium.
- Longevity ritual bonus moved next to decrepitude stats and now available to all type of characters.
- Rework of DiaryEntry sheet:
  - Active effects bonus is not displayed twice
  - Added max level to each progress item to prevent overflow by active effect.