### PR TITLE
Add right click dropdown descriptions for item lists

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -929,6 +929,16 @@ export class ArM5eActorSheet extends ActorSheet {
       item.sheet.render(true, { focus: true });
     });
 
+    html.find(".item").contextmenu(ev => {
+      let li = ev.currentTarget;
+      let item = this.document.items.get(li.dataset.itemId);
+      if (item && item.system.description)
+      {
+        this._onDropdown($(ev.currentTarget), item.system.description);
+      }
+
+    })
+
     // Update Inventory Item
     html.find(".book-edit").click(async (ev) => {
       const li = $(ev.currentTarget).parents(".item");
@@ -1240,6 +1250,30 @@ export class ArM5eActorSheet extends ActorSheet {
     // }
 
     return await this.actor.createEmbeddedDocuments("Item", itemData, {});
+  }
+
+  /**
+   * Adds dropdown text for a specified element.
+   * 
+   * @param {HTMLElement} element Parent element for dropdown
+   * @param {string} text Text in the dropdown
+   */
+  _onDropdown(element, text)
+  {
+    let summary = element.next()
+    
+    if (summary.hasClass("item-summary")) // If summary is present, remove
+    {
+        summary.slideUp(200, () => summary.remove());
+    }
+    else 
+    {
+        summary = $(`<div class="item-summary">${text}</div>`)
+        summary.hide();
+        summary.insertAfter(element);
+        summary.slideDown(200);
+        
+    }
   }
 
   /* Handle covenant pick */


### PR DESCRIPTION
I weary of opening item sheets to read descriptions, so I've added a simple right click dropdown for item lists.

I would much prefer to add the `item-summary` element within the list item itself, but since it's a flexrow it's not possible to get it below the item row (or at least, I don't know the CSS to get it to do so). Instead, it adds the summary as a sibling element next to the item element.

https://github.com/Xzotl42/arm5e/assets/28637157/5862817b-ef87-4239-9738-d842bd8d060d

