### PR TITLE
Prevent stretching in actor/item images

### DIFF
--- a/css/arm5e.css
+++ b/css/arm5e.css
@@ -1057,6 +1057,7 @@ input[type="time"] {
   width: 100px;
   margin-right: 5px;
   margin-bottom: 5px;
+  object-fit: contain;
 }
 
 .arm5e .sheet-header .item-img {
@@ -1066,6 +1067,7 @@ input[type="time"] {
   height: 200px;
   margin-right: 16px;
   margin-bottom: 16px;
+  object-fit: contain;
 }
 
 .arm5e .sheet-header .header-fields {


### PR DESCRIPTION
For example:

Currently
![image](https://github.com/Xzotl42/arm5e/assets/28637157/e7d525da-ee22-443b-9351-2b1e1976e911)

After fix
![image](https://github.com/Xzotl42/arm5e/assets/28637157/ff9cb415-1e6e-49fa-9fb6-11ecfc4e36eb)
