### PR TITLE
Wound recovery BF2

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,9 +1,11 @@
-## 2.1.1.3, Mercere, the Spymaster
+## 2.1.1.4, Mercere, the Spymaster
 
 ### Features & changes
 
 - New sanatorium dialog for wounds recovery (assets by @Sylph).
 - Wound are now items.
+- Calendar scrollbar state is memorized between changes
+- It is possible to edit the duration of some activities
 
 ### Bug fixes
 
@@ -11,6 +13,10 @@
 - New French, Spanish and Italian versions by @Orneen, @Teotimus and @N0Br41nZ
 - Fixed some schedule conflict issues
 - It is now possible to enable magical focus when learning spells
+- Empty aura field results in aura of 0
+- Seasonal activities not created directly (eg: aging, recovery, lab work) are now hidden in diary sheet's activity type selection
+- non applied activities get back their red aura in the schedule dialog.
+- changing the activity type to a shorter duration remove the extra scheduled dates
 
 ## 2.1.0.18, Mercere, the Giftless
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1154,6 +1154,7 @@
   "arm5e.activity.teacher.name": "Teacher's name",
   "arm5e.activity.teacher.score": "Teacher's score",
   "arm5e.activity.book.title": "Title",
+  "arm5e.activity.schedule.label": "Activity schedule",
 
   "arm5e.astrolab.setWorldDate": "Set world date",
   "arm5e.astrolab.updateActors": "Update actors",
@@ -1208,7 +1209,7 @@
   "arm5e.sheet.wound.gravity": "Gravity",
   "arm5e.sheet.wound.recovery": "Recovery time",
   "arm5e.sheet.wound.fresh": "Treatment not started",
-
+  "arm5e.sheet.wound.inrecovery": "In recovery",
   "arm5e.book.tableContents": "Table of contents",
   "arm5e.book.summaLong": "Summa of level {level} and quality {quality} about",
   "arm5e.book.tractLong": "Tractatus of quality {quality} about",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -269,7 +269,7 @@ export class ArM5eActorSheet extends ActorSheet {
     }
 
     context.system.isCharacter = this.actor._isCharacter();
-    if (this.actor._isCharacter()) {
+    if (context.system.isCharacter) {
       for (let [key, v] of Object.entries(context.system.vitals)) {
         v.label = game.i18n.localize(CONFIG.ARM5E.character.vitals[key].label);
       }
@@ -384,7 +384,7 @@ export class ArM5eActorSheet extends ActorSheet {
             }
           }
         } else {
-          if (context.system.labtotal.aura === undefined) {
+          if (!Number.isNumeric(context.system.labtotal.aura)) {
             context.system.labtotal.aura = 0;
           }
         }

--- a/module/config.js
+++ b/module/config.js
@@ -2116,6 +2116,7 @@ ARM5E.activities.generic = {
     validation: validTotalXp,
     secondaryFilter: null,
     duration: 60,
+    durationEdit: true,
     scheduling: {
       duplicate: false,
       conflict: true
@@ -2136,6 +2137,8 @@ ARM5E.activities.generic = {
     bonusOptions: null,
     validation: validChildhood,
     secondaryFilter: null,
+    duration: 20,
+    durationEdit: true,
     scheduling: {
       duplicate: false,
       conflict: true
@@ -2157,6 +2160,7 @@ ARM5E.activities.generic = {
     validation: validTotalXp,
     secondaryFilter: null,
     duration: 4,
+    durationEdit: true,
     scheduling: {
       duplicate: false,
       conflict: true
@@ -2178,6 +2182,7 @@ ARM5E.activities.generic = {
     validation: validTotalXp,
     secondaryFilter: null,
     duration: 4,
+    durationEdit: true,
     scheduling: {
       duplicate: false,
       conflict: true
@@ -2192,7 +2197,7 @@ ARM5E.activities.generic = {
       arts: true,
       masteries: true,
       spells: false,
-      choosable: "disabled"
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,
@@ -2213,7 +2218,7 @@ ARM5E.activities.generic = {
       arts: false,
       masteries: false,
       spells: true,
-      choosable: "disabled"
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,
@@ -2234,7 +2239,7 @@ ARM5E.activities.generic = {
       arts: false,
       masteries: false,
       spells: true,
-      choosable: "disabled"
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,
@@ -2255,7 +2260,7 @@ ARM5E.activities.generic = {
       arts: false,
       masteries: false,
       spells: false,
-      choosable: "disabled"
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,
@@ -2288,7 +2293,8 @@ ARM5E.activities.generic = {
       abilities: false,
       arts: false,
       masteries: false,
-      spells: false
+      spells: false,
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,
@@ -2310,7 +2316,7 @@ ARM5E.activities.generic = {
       arts: true,
       masteries: false,
       spells: false,
-      choosable: "disabled"
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,
@@ -2331,7 +2337,8 @@ ARM5E.activities.generic = {
       abilities: false,
       arts: false,
       masteries: false,
-      spells: false
+      spells: false,
+      attribute: "hidden"
     },
     source: { default: 0, readonly: true },
     maxXp: 0,

--- a/module/schemas/woundSchema.js
+++ b/module/schemas/woundSchema.js
@@ -120,16 +120,11 @@ export class WoundSchema extends foundry.abstract.DataModel {
       return false;
     }
 
-    if (
-      year == this.inflictedDate.year &&
-      CONFIG.SEASON_ORDER[season] < CONFIG.SEASON_ORDER[this.inflictedDate.season]
-    ) {
-      return false;
-    }
     const delta = seasonsDelta(
       { season: this.inflictedDate.season, year: this.inflictedDate.year },
       { season: season, year: year }
     );
+    if (delta < 0) return; // trying to heal in the past
     log(
       false,
       `Delta ${delta} +1 x days : ${(delta + 1) * CONFIG.ARM5E.recovery.daysInSeason} versus ${

--- a/module/tools/activity-schedule.js
+++ b/module/tools/activity-schedule.js
@@ -24,6 +24,7 @@ export class ActivitySchedule extends FormApplication {
       template: "systems/arm5e/templates/generic/activity-schedule.html",
       width: "600",
       height: "790",
+      scrollY: [".years"],
       submitOnChange: false,
       closeOnSubmit: false
     });
@@ -37,7 +38,7 @@ export class ActivitySchedule extends FormApplication {
     let dates = data.dates;
     data.duration = data.activity.system.duration;
     data.activityName = `${data.actor.name} : ${data.activity.name}`;
-    data.title = game.i18n.localize("arm5e.lab.planning.label");
+    data.title = game.i18n.localize("arm5e.activity.schedule.label");
     if (dates.length == 0) {
       // all season unselected, use current date
       data.firstYear = data.curYear;

--- a/module/tools/group-schedule.js
+++ b/module/tools/group-schedule.js
@@ -17,6 +17,7 @@ export class GroupSchedule extends FormApplication {
       template: "systems/arm5e/templates/generic/group-schedule.html",
       width: "600",
       height: "790",
+      scrollY: [".years"],
       submitOnChange: false,
       closeOnSubmit: false
     });

--- a/module/tools/sanatorium.js
+++ b/module/tools/sanatorium.js
@@ -78,8 +78,6 @@ export class Sanatorium extends FormApplication {
       );
       context.canRoll = "disabled";
       context.diary = "disabled";
-    } else if (context.daysLeft == 0) {
-      context.canRoll = "disabled";
     } else if (
       Object.entries(context.wounds).filter(
         (e) => CONFIG.ARM5E.recovery.wounds[e[0]].rank > 0 && e[1] != []
@@ -153,6 +151,10 @@ export class Sanatorium extends FormApplication {
         let data = {};
         data.system = wound;
         data.system.gravity = type;
+        data.system.description =
+          `<h3>${game.i18n.localize(CONFIG.ARM5E.seasons[this.object.curSeason].label)} ${
+            this.object.curYear
+          }</h3><br/>` + data.system.description;
         data.name = wound.name;
         data.img = wound.img;
         data._id = wound._id;
@@ -241,6 +243,7 @@ export class Sanatorium extends FormApplication {
           log(false, `Next roll ${incap.nextRoll} > ${this.object.nextRecoveryPeriod} or locked`);
           if (!incap.locked) {
             tmpPeriod = tmpPeriod < incap.nextRoll ? tmpPeriod : incap.nextRoll;
+            this.object.hasWounds = true;
           }
           newWounds["incap"].push(incap);
           continue;
@@ -309,11 +312,13 @@ export class Sanatorium extends FormApplication {
         }
         woundPeriodDescription += "<br/></li>";
         newWound.img = CONFIG.ARM5E.recovery.wounds[newType].icon;
-        newWound.name = game.i18n.localize(CONFIG.ARM5E.recovery.wounds[newType].label);
-        newWound.description += woundPeriodDescription + "</ul>";
-        recoverylog += woundPeriodDescription;
+        newWound.name = `${game.i18n.localize(
+          CONFIG.ARM5E.recovery.wounds[newType].label
+        )} ${game.i18n.localize("arm5e.sheet.wound.label")}`;
+
         newWound.nextRoll = incap.nextRoll + CONFIG.ARM5E.recovery.wounds[newType].interval;
         newWound.recoveryTime += CONFIG.ARM5E.recovery.wounds[newType].interval;
+        recoverylog += woundPeriodDescription;
         log(false, `Next roll: ${newWound.nextRoll}`);
         if (newWound.nextRoll > this.object.availableDays) {
           log(false, `Locked for this season`);
@@ -324,6 +329,9 @@ export class Sanatorium extends FormApplication {
           tmpPeriod = tmpPeriod < newWound.nextRoll ? tmpPeriod : newWound.nextRoll;
           log(false, `New Period: ${tmpPeriod}`);
         }
+
+        newWound.description += woundPeriodDescription + "</ul>";
+
         newWounds[newType].push(newWound);
       }
     }
@@ -341,6 +349,7 @@ export class Sanatorium extends FormApplication {
             log(false, `Next roll ${wound.nextRoll} > ${this.object.nextRecoveryPeriod} or locked`);
             if (!wound.locked) {
               tmpPeriod = tmpPeriod < wound.nextRoll ? tmpPeriod : wound.nextRoll;
+              this.object.hasWounds = true;
             }
             newWounds[type].push(wound);
             continue;
@@ -366,13 +375,18 @@ export class Sanatorium extends FormApplication {
             if (newType == "healthy") {
               newWound.locked = true;
 
-              woundPeriodDescription += `${game.i18n.format("arm5e.sanatorium.msg.logHealed", {
+              woundPeriodDescription += `${game.i18n.localize(
+                "arm5e.sheet." + wound.originalGravity
+              )} ${game.i18n.format("arm5e.sanatorium.msg.logHealed", {
                 days: newWound.recoveryTime
               })}<br/>`;
-              newWound.description += woundPeriodDescription;
+
               recoverylog += woundPeriodDescription;
+              newWound.description += woundPeriodDescription;
               newWound.img = CONFIG.ARM5E.recovery.wounds[newType].icon;
-              newWound.name = game.i18n.localize(CONFIG.ARM5E.recovery.wounds[newType].label);
+              newWound.name = `${game.i18n.localize(
+                CONFIG.ARM5E.recovery.wounds[newType].label
+              )} ${game.i18n.localize("arm5e.sheet.wound.label")}`;
               wound.nextRoll = 0;
               newWounds[newType].push(newWound);
               continue;
@@ -422,9 +436,12 @@ export class Sanatorium extends FormApplication {
             }
             woundPeriodDescription += "<br/></li>";
             newWound.img = CONFIG.ARM5E.recovery.wounds[newType].icon;
-            newWound.name = game.i18n.localize(CONFIG.ARM5E.recovery.wounds[newType].label);
-            newWound.description += woundPeriodDescription + "</ul>";
+            newWound.name = `${game.i18n.localize(
+              CONFIG.ARM5E.recovery.wounds[newType].label
+            )} ${game.i18n.localize("arm5e.sheet.wound.label")}`;
+
             recoverylog += woundPeriodDescription;
+
             newWound.nextRoll = wound.nextRoll + CONFIG.ARM5E.recovery.wounds[newType].interval;
             newWound.recoveryTime += CONFIG.ARM5E.recovery.wounds[newType].interval;
             log(false, `Next roll: ${newWound.nextRoll}`);
@@ -437,6 +454,7 @@ export class Sanatorium extends FormApplication {
               tmpPeriod = tmpPeriod < newWound.nextRoll ? tmpPeriod : newWound.nextRoll;
               log(false, `New Period: ${tmpPeriod}`);
             }
+            newWound.description += woundPeriodDescription + "</ul>";
             newWounds[newType].push(newWound);
           }
         }

--- a/module/tools/schedule.js
+++ b/module/tools/schedule.js
@@ -16,6 +16,7 @@ export class Schedule extends FormApplication {
       template: "systems/arm5e/templates/generic/character-schedule.html",
       width: "600",
       height: "790",
+      scrollY: [".years"],
       submitOnChange: false,
       closeOnSubmit: false
     });

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "name": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT",
-  "version": "2.1.1.3",
+  "version": "2.1.1.4",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",

--- a/templates/actor/parts/actor-diary.html
+++ b/templates/actor/parts/actor-diary.html
@@ -12,9 +12,11 @@
       </div>
     </div>
   {{/if}}
-  <div class="resource">
-    <a class="character-schedule flex0" style="width:50px"><i class="icon-Tool_AstrolabBig"></i></a>
-  </div>
+  {{#if system.isCharacter}}
+    <div class="resource">
+      <a class="character-schedule flex0" style="width:50px"><i class="icon-Tool_AstrolabBig"></i></a>
+    </div>
+  {{/if}}
 </div>
 
 <ol class="items-list backSection margintop18">

--- a/templates/generic/activity-schedule.html
+++ b/templates/generic/activity-schedule.html
@@ -26,7 +26,7 @@
 
     </div>
     <div>
-      {{> "systems/arm5e/templates/generic/calendar-grid.html" type="calendar"}}
+      {{> "systems/arm5e/templates/generic/calendar-grid.html"}}
     </div>
     <div class="flexrow padding12">
       <div class="flex-group-center">

--- a/templates/generic/calendar-grid.html
+++ b/templates/generic/calendar-grid.html
@@ -8,7 +8,7 @@
 <div style="margin-left:-10px; margin-right: -16px;">
   {{> "systems/arm5e/templates/generic/metalic-bar.html" topoffset="-7px" }}
 </div>
-<div class="{{type}}-years flexcol">
+<div class="years flexcol">
   {{#each selectedDates }}
     <div class="backSection calendar-year flex-center flex-between">
       <label for="year" class="smallTitle" style="font-size:16pt">{{this.year}}</label>
@@ -17,7 +17,8 @@
           <div class="calendar-season {{this.style}} flexrow">
             <div class="flexrow">
               {{#each this.others}}
-                <div class="vignette" data-id="{{this.id}}"><img src="{{this.img}}" title="{{this.name}}" /> </div>
+                <div class="vignette" data-id="{{this.id}}"><img src="{{this.img}}" title="{{this.name}}"
+                    {{{this.style}}} /> </div>
               {{/each}}
             </div>
             {{#if this.edition}}

--- a/templates/generic/group-schedule-grid.html
+++ b/templates/generic/group-schedule-grid.html
@@ -11,7 +11,7 @@
 <div style="margin-left:-10px; margin-right: -16px;">
   {{> "systems/arm5e/templates/generic/metalic-bar.html" topoffset="-7px" }}
 </div>
-<div class="{{type}}-years flexcol">
+<div class="years flexcol">
   {{#each selectedActors }}
     <div class="backSection calendar-year flex-center flex-between">
 
@@ -23,8 +23,8 @@
             data-year="{{../this.year}}" data-season="{{@key}}" data-actor="{{../this.id}}" title="Create activity">
             <div class="flexrow">
               {{#each this.activities}}
-                <div class="vignette" data-actorid={{../../this.id}} data-id="{{this.id}}"><img src="{{this.img}}"
-                    title="{{this.name}}" />
+                <div class="vignette" data-actorid={{../../this.id}} data-id="{{this.id}}" {{{this.style}}}><img
+                    src="{{this.img}}" title="{{this.name}}" />
                 </div>
               {{/each}}
               <div style="max-width: 25px; max-height: 25px; height: 25px; width: 25px;">

--- a/templates/generic/group-schedule.html
+++ b/templates/generic/group-schedule.html
@@ -31,7 +31,7 @@
       </select>
     </div>
     <div>
-      {{> "systems/arm5e/templates/generic/group-schedule-grid.html" type="schedule" }}
+      {{> "systems/arm5e/templates/generic/group-schedule-grid.html" }}
     </div>
   </div>
 

--- a/templates/generic/schedule-grid.html
+++ b/templates/generic/schedule-grid.html
@@ -18,7 +18,8 @@
             data-year="{{../this.year}}" data-season="{{@key}}" title="Create activity">
             <div class="flexrow">
               {{#each this.others}}
-                <div class="vignette" data-id="{{this.id}}"><img src="{{this.img}}" title="{{this.name}}" /> </div>
+                <div class="vignette" data-id="{{this.id}}"><img src="{{this.img}}" title="{{this.name}}"
+                    {{{this.style}}} /> </div>
               {{/each}}
               <div style="max-width: 25px; max-height: 25px; height: 25px; width: 25px;">
               </div>

--- a/templates/item/item-diaryEntry-sheet.html
+++ b/templates/item/item-diaryEntry-sheet.html
@@ -54,7 +54,7 @@
             {{@root.system.disabled}}>
             {{#select system.activity}} {{#each config.activities.generic as |activity key|}}
 
-                <option value="{{key}}" {{activity.display.choosable}}>{{localize activity.label}}</option>
+                <option value="{{key}}" {{activity.display.attribute}}>{{localize activity.label}}</option>
               {{/each}} {{/select}}
           </select>
         </div>
@@ -62,8 +62,8 @@
 
       <div class="flexrow">
         <div class="flex01">
-          <label>{{localize "arm5e.sheet.duration"}}</label> <input type="number" name="system.duration"
-            value="{{system.duration}}" data-dtype="Number" readonly />
+          <label>{{localize "arm5e.sheet.duration"}}</label> <input type="number" class="duration"
+            name="system.duration" value="{{system.duration}}" data-dtype="Number" {{ui.editDuration}} />
         </div>
         {{#unless system.done}}
           <div class="resource">

--- a/templates/item/item-wound-sheet.html
+++ b/templates/item/item-wound-sheet.html
@@ -34,8 +34,11 @@
             </select>
             <input type="number" name="system.healedDate.year" value="{{system.healedDate.year}}" data-dtype="Number" />
           {{else}}
-
-            {{localize "arm5e.sheet.wound.fresh"}}
+            {{#if system.recoveryTime}}
+              {{localize "arm5e.sheet.wound.inrecovery"}}
+            {{else}}
+              {{localize "arm5e.sheet.wound.fresh"}}
+            {{/if}}
           {{/if}}
         </div>
       </div>


### PR DESCRIPTION
- Improved medical log
- Calendar scrollbar state is memorized between changes
- It is possible to edit the duration of some activities

- Empty aura field results in aura of 0
- Seasonal activities not created directly (eg: aging, recovery, lab work) are now hidden in diary sheet's activity type selection
- non applied activities get back their red aura in the schedule dialog.
- changing the activity type to a shorter duration remove the extra scheduled dates
- Fix bug where next recovery roll is exactly at the end of the season.