### PR TITLE
DSN fix, effect dupl fix

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,12 @@
+## 2.2.2.3, Nicodemus Ex Miscellanea
+
+### Bug fixes
+
+- Ritual magic now adds the proper number of fatigue levels
+- Fixed bug with Dice So Nice integration where rolling for botch always seemed to result in one.
+- Spontaneous casting without casting now displays its chat message respecting the roll mode instead of always private.
+- Fixed migration bug in V11 where effects coming from Items were kept duplicated.
+
 ## 2.2.2.2, Nicodemus crippled by Twilight
 
 ### Features & changes

--- a/module/helpers/rollWindow.js
+++ b/module/helpers/rollWindow.js
@@ -392,10 +392,10 @@ async function castSpell(actorCaster, roll, message) {
     });
   }
   if (actorCaster.rollData.type == "spell") {
-    if (totalOfSpell < levelOfSpell) {
+    if (totalOfSpell < levelOfSpell || actorCaster.rollData.magic.ritual) {
       let fatigue = 1;
       if (actorCaster.rollData.magic.ritual) {
-        fatigue = Math.ceil((levelOfSpell - totalOfSpell) / 5);
+        fatigue = Math.max(Math.ceil((levelOfSpell - totalOfSpell) / 5), 1);
       }
       // lose fatigue levels
       await actorCaster.loseFatigueLevel(fatigue);

--- a/module/migration.js
+++ b/module/migration.js
@@ -747,7 +747,18 @@ export const migrateActorData = async function (actorDoc, actorItems) {
         let toDelete = [];
         for (let e of applied) {
           // if effect comes from an item, no need to migrate it.
-          if (e.transfer == true) continue;
+          if (e.transfer == true) {
+            continue;
+          } else {
+            const [actorPrefix, actorId, itemPrefix, itemId] = e.origin?.split(".") ?? [];
+            if (itemPrefix && actorDoc.items.has(itemId)) {
+              if (actorDoc instanceof ArM5ePCActor) {
+                toDelete.push(e._id);
+                continue;
+              }
+            }
+          }
+
           if (isEffectObsolete(e)) {
             if (actorDoc instanceof ArM5ePCActor) {
               toDelete.push(e._id);

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "name": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT",
-  "version": "2.2.2.2",
+  "version": "2.2.2.3",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",


### PR DESCRIPTION
### Bug fixes

- Ritual magic now adds the proper number of fatigue levels
- Fixed bug with Dice So Nice integration where rolling for botch always seemed to result in one.
- Spontaneous casting without casting now displays its chat message respecting the roll mode instead of always private.
- Fixed migration bug in V11 where effects coming from Items were kept duplicated.