### PR TITLE
Fixes for V11 AE

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-## 2.2.2.5, Nicodemus Ex Miscellanea
+## 2.2.2.6, Nicodemus Ex Miscellanea
 
 ### Bug fixes
 
@@ -6,6 +6,10 @@
 - Fixed bug with Dice So Nice integration where rolling for botch always seemed to result in one.
 - Spontaneous casting without casting now displays its chat message respecting the roll mode instead of always private.
 - Fixed migration bug in V11 where effects coming from Items were kept duplicated.
+- Improved migration for unlinked tokens
+- Effect tab displays all applicable effects
+- Changing aging point no longer raises an error.
+- It is not possible anymore to delete active effects belonging to Items on the actor sheet.
 
 ## 2.2.2.2, Nicodemus crippled by Twilight
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -734,7 +734,7 @@ export class ArM5eActorSheet extends ActorSheet {
 
     // Prepare active effects
     context.effects = ArM5eActiveEffect.prepareActiveEffectCategories(
-      this.actor.allApplicableEffects()
+      CONFIG.ISV10 ? this.actor.effects : Array.from(this.actor.allApplicableEffects())
     );
     this._prepareCharacterItems(context);
 
@@ -1191,7 +1191,7 @@ export class ArM5eActorSheet extends ActorSheet {
           if (Number.isNumeric(input.val())) {
             newVal = Number(input.val());
           }
-          const updateData = [];
+          const updateData = {};
           if (newVal > Math.abs(score)) {
             newVal = 0;
             updateData[`system.characteristics.${dataset.characteristic}.value`] =

--- a/module/helpers/active-effects.js
+++ b/module/helpers/active-effects.js
@@ -1,4 +1,6 @@
+import { ArM5ePCActor } from "../actor/actor.js";
 import ACTIVE_EFFECTS_TYPES from "../constants/activeEffectsTypes.js";
+// import { ArM5eItem } from "../item/item.js";
 import { log } from "../tools.js";
 /**
  * Extend the base ActiveEffect class to implement system-specific logic.
@@ -23,6 +25,10 @@ export default class ArM5eActiveEffect extends ActiveEffect {
         ((this.parent.documentName === "Item" && this.parent.isOwned == true) ||
           (this.parent.documentName === "Actor" && this.origin?.includes("Item")))) ||
       this.getFlag("arm5e", "noEdit");
+    this.noDelete =
+      // (CONFIG.ISV10 && this.noEdit) ||
+      (this.parent.documentName === "Item" && this.parent.isOwned == true) ||
+      (this.parent.documentName === "Actor" && this.origin?.includes("Item"));
   }
 
   /** @inheritdoc */
@@ -47,12 +53,13 @@ export default class ArM5eActiveEffect extends ActiveEffect {
     const a = event.currentTarget;
     const li = a.closest("li");
     let effect;
-    if (CONFIG.ISV10) {
+    if (CONFIG.ISV10 || !owner.allApplicableEffects) {
       effect = li.dataset.effectId ? owner.effects.get(li.dataset.effectId) : null;
     } else {
       let effects = Array.from(owner.allApplicableEffects());
       effect = effects.find((e) => e._id == li.dataset.effectId);
     }
+
     switch (a.dataset.action) {
       case "create":
         const data = {

--- a/module/migration.js
+++ b/module/migration.js
@@ -511,11 +511,15 @@ export const migrateActorData = async function (actorDoc, actorItems) {
         }
         updateData["system.-=reputation"] = null;
       } else {
-        ChatMessage.create({
-          content:
-            "<b>MIGRATION NOTIFICATION</b><br/>" +
-            `The character ${actor.name} was unable to migrate his/her reputations. Triggering a new migration will fix it (See FAQ)`
-        });
+        if (actorDoc.synthetic) {
+          updateData["system.-=reputation"] = null;
+        } else {
+          ChatMessage.create({
+            content:
+              "<b>MIGRATION NOTIFICATION</b><br/>" +
+              `The character ${actor.name} was unable to migrate his/her reputations. Triggering a new migration will fix it (See FAQ)`
+          });
+        }
       }
     }
 
@@ -539,11 +543,15 @@ export const migrateActorData = async function (actorDoc, actorItems) {
         }
         updateData["system.-=personality"] = null;
       } else {
-        ChatMessage.create({
-          content:
-            "<b>MIGRATION NOTIFICATION</b><br/>" +
-            `The character ${actor.name} was unable to migrate his/her personality traits. Triggering a new migration will fix it (See FAQ)`
-        });
+        if (actorDoc.synthetic) {
+          updateData["system.-=personality"] = null;
+        } else {
+          ChatMessage.create({
+            content:
+              "<b>MIGRATION NOTIFICATION</b><br/>" +
+              `The character ${actor.name} was unable to migrate his/her personality traits. Triggering a new migration will fix it (See FAQ)`
+          });
+        }
       }
     }
   } else {
@@ -741,7 +749,10 @@ export const migrateActorData = async function (actorDoc, actorItems) {
         }
       }
     } else {
-      const applied = Array.from(actorDoc.allApplicableEffects());
+      let applied = actorDoc.effects;
+      if (actorDoc instanceof ArM5ePCActor) {
+        applied = Array.from(actorDoc.allApplicableEffects());
+      }
       if (applied && applied.length > 0) {
         let effects = [];
         let toDelete = [];
@@ -754,6 +765,7 @@ export const migrateActorData = async function (actorDoc, actorItems) {
             const [actorPrefix, actorId, itemPrefix, itemId] = e.origin?.split(".") ?? [];
             if (itemPrefix && actorDoc.items.has(itemId)) {
               if (actorDoc instanceof ArM5ePCActor) {
+                console.log(`DEBUG: Found duplicate effect of origin: "${e.origin}", delete it.`);
                 toDelete.push(e._id);
                 continue;
               }

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "name": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT",
-  "version": "2.2.2.5",
+  "version": "2.2.2.6",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",

--- a/templates/actor/actor-beast-sheet.html
+++ b/templates/actor/actor-beast-sheet.html
@@ -134,7 +134,7 @@
 
     {{!-- Effects Tab --}}
     <div class="tab effects" data-group="primary" data-tab="effects">
-      {{> "systems/arm5e/templates/generic/active-effects.html" }}
+      {{> "systems/arm5e/templates/generic/active-effects.html"  mode="actor" }}
     </div>
   </section>
 

--- a/templates/actor/actor-laboratory-sheet.html
+++ b/templates/actor/actor-laboratory-sheet.html
@@ -251,7 +251,7 @@
 
     {{!-- Effects Tab --}}
     <div class="tab effects" data-group="primary" data-tab="effects">
-      {{> "systems/arm5e/templates/generic/active-effects.html" }}
+      {{> "systems/arm5e/templates/generic/active-effects.html"  mode="actor" }}
     </div>
   </section>
 

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -267,7 +267,7 @@
     </div>
     {{!-- Effects Tab --}}
     <div class="tab effects" data-group="primary" data-tab="effects">
-      {{> "systems/arm5e/templates/generic/active-effects.html" }}
+      {{> "systems/arm5e/templates/generic/active-effects.html"  mode="actor" }}
     </div>
   </section>
 

--- a/templates/actor/actor-pc-sheet.html
+++ b/templates/actor/actor-pc-sheet.html
@@ -273,7 +273,7 @@
 
     {{!-- Effects Tab --}}
     <div class="tab effects" data-group="primary" data-tab="effects">
-      {{> "systems/arm5e/templates/generic/active-effects.html" }}
+      {{> "systems/arm5e/templates/generic/active-effects.html" mode="actor" }}
     </div>
   </section>
 

--- a/templates/generic/active-effects.html
+++ b/templates/generic/active-effects.html
@@ -14,6 +14,7 @@
     </li>
 
     <ol class="item-list">
+
       {{#each section.effects as |effect|}}
         <li class="item effect flexrow" data-effect-id="{{effect.id}}">
           <div class="item-name effect-name flexrow">
@@ -34,6 +35,8 @@
               <a class="effect-control" data-action="edit" title="{{localize 'arm5e.sheet.effectsEdit'}}">
                 <i class="icon-Icon_Edit"></i>
               </a>
+            {{/unless}}
+            {{#unless (and effect.noDelete (eq ../../mode "actor"))}}
               <a class="effect-control" data-action="delete" title="{{localize 'arm5e.sheet.effectsDelete'}}">
                 <i class="icon-Icon_Delete_Hand_Gesture"></i>
               </a>


### PR DESCRIPTION
### Bug fixes

- Ritual magic now adds the proper number of fatigue levels
- Fixed bug with Dice So Nice integration where rolling for botch always seemed to result in one.
- Spontaneous casting without casting now displays its chat message respecting the roll mode instead of always private.
- Fixed migration bug in V11 where effects coming from Items were kept duplicated.
- Improved migration for unlinked tokens
- Effect tab displays all applicable effects
- Changing aging point no longer raises an error.
- It is not possible anymore to delete active effects belonging to Items on the actor sheet.