### PR TITLE
2.2.3 Ophilio BF

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,8 +1,22 @@
-## 2.2.3.26, Ophilio, old
+## 2.2.3.27, Ophilio, old
+
+### Dependencies updates
+
+- arm5e-compendia module minimum version 0.2.6
+
+### Features & changes
+
+- Retrieve generic abilities from ref compendia even with an unkown option
 
 ### Bug fixes
 
-- It is no longer impossible to add a skill in a diary entry if you have animal handling.
+- Diary sheet fixes:
+  - It is no longer impossible to add a skill in a diary entry if you have animal handling.
+  - You can again add an ability progress item with a virtual teacher
+  - Added some robustness, the + sign fro progress items will disappear if all possibilities are exhausted.
+  - Generic abilities learned from a teacher are set properly.
+  - Spells tab is no longer visible in teaching activities (until it is implemented)
+  - bunch of small fixes
 
 ## 2.2.3.25, Ophilio, getting old
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+- Covenant UI flavor has the proper case
 - Diary sheet fixes:
   - It is no longer impossible to add a skill in a diary entry if you have animal handling.
   - You can again add an ability progress item with a virtual teacher

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,9 @@
+## 2.2.3.26, Ophilio, old
+
+### Bug fixes
+
+- It is no longer impossible to add a skill in a diary entry if you have animal handling.
+
 ## 2.2.3.25, Ophilio, getting old
 
 ### Features & changes

--- a/lang/en.json
+++ b/lang/en.json
@@ -499,8 +499,8 @@
   "arm5e.skill.options.profession": "Prof's name",
   "arm5e.skill.options.language": "Language's name",
   "arm5e.skill.options.organization": "Org's name",
-  "arm5e.skill.options.martial": "Ability's name",
-  "arm5e.skill.options.academic": "Ability's name",
+  "arm5e.skill.options.martial": "Weapon's type",
+  "arm5e.skill.options.academic": "Topic's name",
   "arm5e.skill.options.arcane": "Ability's name",
   "arm5e.skill.options.supernatural": "Ability's name",
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1611,7 +1611,7 @@ export class ArM5eActorSheet extends ActorSheet {
       case "beast":
         return "NPC";
       case "covenant":
-        return "Covenant";
+        return "covenant";
       case "laboratory":
         return "Lab";
       default:

--- a/module/actor/subsheets/actor-profiles.js
+++ b/module/actor/subsheets/actor-profiles.js
@@ -25,7 +25,7 @@ export class ArM5eActorProfiles {
         console.error("Wrong actor config");
         continue;
       }
-      ability = ability.toObject();
+      // ability = ability.toObject();
       if (ab.xp) {
         ability.system.xp = ab.xp;
       }

--- a/module/config.js
+++ b/module/config.js
@@ -355,7 +355,8 @@ ARM5E.GENERAL_ABILITIES = {
     option: true,
     category: "general",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.area"
+    optionPlaceholder: "arm5e.skill.options.area",
+    optionDefault: "AreaName"
   },
   athletics: {
     mnemonic: "arm5e.skill.general.athletics",
@@ -410,7 +411,8 @@ ARM5E.GENERAL_ABILITIES = {
     option: true,
     category: "general",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.craft"
+    optionPlaceholder: "arm5e.skill.options.craft",
+    optionDefault: "craft"
   },
   etiquette: {
     mnemonic: "arm5e.skill.general.etiquette",
@@ -454,7 +456,8 @@ ARM5E.GENERAL_ABILITIES = {
     option: true,
     category: "general",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.language"
+    optionPlaceholder: "arm5e.skill.options.language",
+    optionDefault: "languageName"
   },
   music: {
     mnemonic: "arm5e.skill.general.music",
@@ -467,14 +470,16 @@ ARM5E.GENERAL_ABILITIES = {
     option: true,
     category: "general",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.organization"
+    optionPlaceholder: "arm5e.skill.options.organization",
+    optionDefault: "OrgName"
   },
   profession: {
     mnemonic: "arm5e.skill.general.profession",
     option: true,
     category: "general",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.profession"
+    optionPlaceholder: "arm5e.skill.options.profession",
+    optionDefault: "ProfessionName"
   },
   ride: { mnemonic: "arm5e.skill.general.ride", option: false, category: "general", selection: "" },
   stealth: {
@@ -510,14 +515,16 @@ ARM5E.ACADEMIC_ABILITIES = {
     option: true,
     category: "academic",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.law"
+    optionPlaceholder: "arm5e.skill.options.law",
+    optionDefault: "legalForum"
   },
   deadLanguage: {
     mnemonic: "arm5e.skill.academic.deadLanguage",
     option: true,
     category: "academic",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.language"
+    optionPlaceholder: "arm5e.skill.options.language",
+    optionDefault: "languageName"
   },
   medicine: {
     mnemonic: "arm5e.skill.academic.medicine",
@@ -542,7 +549,8 @@ ARM5E.ACADEMIC_ABILITIES = {
     option: true,
     category: "academic",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.academic"
+    optionPlaceholder: "arm5e.skill.options.academic",
+    optionDefault: "topicName"
   }
 };
 
@@ -601,7 +609,8 @@ ARM5E.ARCANE_ABILITIES = {
     option: true,
     category: "arcane",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.arcane"
+    optionPlaceholder: "arm5e.skill.options.arcane",
+    defaultOption: "arcaneName"
   }
 };
 
@@ -631,7 +640,8 @@ ARM5E.MARTIAL_ABILITIES = {
     option: true,
     category: "martial",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.martial"
+    optionPlaceholder: "arm5e.skill.options.martial",
+    defaultOption: "weaponType"
   }
 };
 
@@ -695,7 +705,8 @@ ARM5E.SUPERNATURAL_ABILITIES = {
     option: true,
     category: "supernaturalCat",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.supernatural"
+    optionPlaceholder: "arm5e.skill.options.supernatural",
+    optionDefault: "powerName"
   },
   wildernessSense: {
     mnemonic: "arm5e.skill.supernatural.wildernessSense",
@@ -734,7 +745,8 @@ ARM5E.MYSTERY_ABILITIES = {
     option: true,
     category: "mystery",
     selection: "",
-    optionPlaceholder: "arm5e.skill.options.mysteryCult"
+    optionPlaceholder: "arm5e.skill.options.mysteryCult",
+    optionDefault: "cultName"
   }
 };
 
@@ -2139,7 +2151,7 @@ ARM5E.activities.generic = {
       abilities: true,
       arts: true,
       masteries: true,
-      spells: true
+      spells: false
     },
     source: { default: null, readonly: true },
     maxXp: 0,

--- a/module/helpers/long-term-activities.js
+++ b/module/helpers/long-term-activities.js
@@ -514,19 +514,16 @@ export function validTraining(context, actor, item) {
   if (abilitiesArr.length > 0) {
     const teacherScore = Number(item.system.progress.abilities[0].teacherScore);
     context.system.sourceQuality = teacherScore + 3;
+
+    const taughtAb = item.system.progress.abilities[0];
+
     let ability = Object.values(actor.system.abilities).find((e) => {
-      return e._id === item.system.progress.abilities[0].id;
+      return e._id === taughtAb.id;
     });
     if (ability === undefined) {
-      // either the ability is no longer teachable or it has been deleted
-      ability = actor.items.get(item.system.progress.abilities[0].id);
-
-      if (ability === undefined) {
-        // ability deleted
-        // what should be done here?
-        return;
-      }
+      ability = { system: { key: taughtAb.key, option: taughtAb.option, xp: 0 } };
     }
+
     const coeff = actor._getAbilityXpCoeff(ability.system.key, ability.system.option);
     checkIfCapped(context, teacherScore, coeff, ability);
 
@@ -601,19 +598,13 @@ export function validTeaching(context, actor, item) {
           : context.system.teacher.name;
       return;
     }
+    const taughtAb = item.system.progress.abilities[0];
 
     let ability = Object.values(actor.system.abilities).find((e) => {
-      return e._id === item.system.progress.abilities[0].id;
+      return e._id === taughtAb.id;
     });
     if (ability === undefined) {
-      // either the ability is no longer teachable or it has been deleted
-      ability = actor.items.get(item.system.progress.abilities[0].id);
-
-      if (ability === undefined) {
-        // ability deleted
-        // what should be done here?
-        return;
-      }
+      ability = { system: { key: taughtAb.key, option: taughtAb.option, xp: 0 } };
     }
     const coeff = actor._getAbilityXpCoeff(ability.system.key, ability.system.option);
     checkIfCapped(context, teacherScore, coeff, ability);

--- a/module/item/item-diary-sheet.js
+++ b/module/item/item-diary-sheet.js
@@ -385,6 +385,7 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
           availableAbilities[found]._id = a._id;
           availableAbilities[found].system.xp = a.system.xp;
           availableAbilities[found].system.finalScore = a.system.finalScore;
+          availableAbilities[found].secondaryId = false;
         } else {
           availableAbilities.push({
             _id: a._id,
@@ -1442,7 +1443,7 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
 
             const hasTeacher = ["training", "teaching"].includes(this.item.system.activity);
             // check if the
-            if (button.dataset.default.length == 16 && !button.dataset.secondary) {
+            if (button.dataset.default.length == 16 && button.dataset.secondary === "false") {
               newAb = this.actor.items.get(button.dataset.default);
             } else {
               if (hasTeacher) {

--- a/module/schemas/diarySchema.js
+++ b/module/schemas/diarySchema.js
@@ -150,6 +150,7 @@ export class DiaryEntrySchema extends foundry.abstract.DataModel {
                 nullable: true,
                 initial: null
               }),
+              name: new fields.StringField({ required: false, blank: true, initial: "" }), // used for secondary source (teacher)
               secondaryId: boolOption(false, true), // true if the id is actually not the final one
               key: new fields.StringField({ required: false, blank: true, initial: "" }),
               option: new fields.StringField({ required: false, blank: true, initial: "" }),

--- a/module/tests/diaryAdventuringTest.js
+++ b/module/tests/diaryAdventuringTest.js
@@ -35,6 +35,7 @@ async function addProgressItem(entry, type, defaultItem, sheetData) {
         type: type,
         action: "add",
         default: defaultItem,
+        secondary: "false",
         teacherscore: sheetData.system.teacherScore
       }
     }

--- a/module/tests/diaryCharCreationTest.js
+++ b/module/tests/diaryCharCreationTest.js
@@ -35,6 +35,7 @@ async function addProgressItem(entry, type, defaultItem, sheetData) {
         type: type,
         action: "add",
         default: defaultItem,
+        secondary: "false",
         teacherscore: sheetData.system.teacherScore
       }
     }

--- a/module/tests/diaryExposureTest.js
+++ b/module/tests/diaryExposureTest.js
@@ -35,6 +35,7 @@ async function addProgressItem(entry, type, defaultItem, sheetData) {
         type: type,
         action: "add",
         default: defaultItem,
+        secondary: "false",
         teacherscore: sheetData.system.teacherScore
       }
     }

--- a/module/tests/diaryTeachingTest.js
+++ b/module/tests/diaryTeachingTest.js
@@ -35,6 +35,7 @@ async function addProgressItem(entry, type, defaultItem, teacherScore) {
         type: type,
         action: "add",
         default: defaultItem,
+        secondary: "false",
         teacherscore: teacherScore ? teacherScore : entry.system.teacher.score
       }
     }

--- a/module/tests/diaryTrainingTest.js
+++ b/module/tests/diaryTrainingTest.js
@@ -35,6 +35,7 @@ async function addProgressItem(entry, type, defaultItem) {
         type: type,
         action: "add",
         default: defaultItem,
+        secondary: "false",
         teacherscore: entry.system.teacher.score
       }
     }

--- a/module/tools/compendia.js
+++ b/module/tools/compendia.js
@@ -24,7 +24,20 @@ async function getAbilityInternal(moduleRef, key, option = "") {
   }
   let res = abilitiesPack.index.find((i) => i.system.key == key && i.system.option == option);
   if (res) {
-    return await fromUuid(res.uuid);
+    let genericAb = await fromUuid(res.uuid);
+    return genericAb.toObject();
+  } else if (option !== "" && CONFIG.ARM5E.ALL_ABILITIES[key].option) {
+    // try to get without specified the option:
+    let optionDefault = game.i18n.localize(CONFIG.ARM5E.ALL_ABILITIES[key].optionDefault);
+
+    res = abilitiesPack.index.find((i) => i.system.key == key && i.system.option == optionDefault);
+    if (res) {
+      let genericAb = await fromUuid(res.uuid);
+      // update the option
+      genericAb = genericAb.toObject();
+      genericAb.system.option = option;
+      return genericAb;
+    }
   }
   return null;
 }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "2.2.3.26",
+  "version": "2.2.3.27",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",
@@ -15,7 +15,7 @@
         "type": "module",
         "manifest": "https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json",
         "compatibility": {
-          "minimum": "0.2.4"
+          "minimum": "0.2.6"
         }
       }
     ]

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "2.2.3.25",
+  "version": "2.2.3.26",
   "minimumCoreVersion": "10.290",
   "compatibility": {
     "minimum": "10.290",


### PR DESCRIPTION
### Dependencies updates

- arm5e-compendia module minimum version 0.2.6

### Features & changes

- Retrieve generic abilities from ref compendia even with an unkown option

### Bug fixes

- Covenant UI flavor has the proper case
- Diary sheet fixes:
  - It is no longer impossible to add a skill in a diary entry if you have animal handling.
  - You can again add an ability progress item with a virtual teacher
  - Added some robustness, the + sign fro progress items will disappear if all possibilities are exhausted.
  - Generic abilities learned from a teacher are set properly.
  - Spells tab is no longer visible in teaching activities (until it is implemented)
  - bunch of small fixes