### PR TITLE
BF3

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,10 @@
+## 2.3.0.10, Quendalon, raised by the Fae BF3
+
+### Bug fixes
+
+- Fixed critical bug where all diary activities created from outside the sheet where reset to standard diary.
+- added new handling of the regio levels field when it is not a number during migration.
+
 ## 2.3.0.9, Quendalon, raised by the Fae BF2
 
 ### Bug fixes

--- a/module/item/item-diary-sheet.js
+++ b/module/item/item-diary-sheet.js
@@ -98,10 +98,15 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
         context.selection.activities[k] = v.label;
       }
     }
+    // if not possible to create it from the sheet disable the selector
+    if (!Object.keys(context.selection.activities).includes(actType)) {
+      context.activityState = "disabled";
+    }
 
     if (this.actor == null || this.actor.type == "covenant" || this.actor.type == "laboratory") {
       context.ui.showTab = false;
       context.system.disabled = "disabled";
+      context.activityState = "disabled";
       return context;
     }
 

--- a/module/schemas/covenantSchema.js
+++ b/module/schemas/covenantSchema.js
@@ -239,6 +239,12 @@ export class CovenantSchema extends foundry.abstract.DataModel {
       update["system.aegisCovenant"] = newValue;
     }
 
+    if (typeof data.system.levelsRegio != "number" || isNaN(data.system.levelsRegio)) {
+      const newValue = convertToNumber(data.system.levelsRegio, 0);
+      descriptionUpdate += `<li>Covenant regio levels is now stricly a number, previous value (${data.system.levelsRegio}) => new value (${newValue})</li>`;
+      update["system.levelsRegio"] = newValue;
+    }
+
     if (data.system.constructionPoints) {
       for (let [k, v] of Object.entries(data.system.constructionPoints.data)) {
         update[`system.buildPoints.${k}`] = { value: v.initials ?? 0, notes: v.notes ?? "" };

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "2.3.0.9",
+  "version": "2.3.0.10",
   "compatibility": {
     "minimum": "10.290",
     "verified": "12.330"

--- a/templates/item/item-diaryEntry-sheet.html
+++ b/templates/item/item-diaryEntry-sheet.html
@@ -47,7 +47,7 @@
         <div class="resource">
           <label class="header-label">{{localize "arm5e.activity.activity"}}</label>
           <select class="progress-activity" name="system.activity" data-type="String" style="width: 100%"
-            {{@root.system.disabled}}>
+            {{@root.activityState}}>
             {{selectOptions selection.activities selected=system.activity localize=true}}
           </select>
         </div>


### PR DESCRIPTION

- Fixed critical bug where all diary activities created from outside the sheet where reset to standard diary.
- added new handling of the regio levels field when it is not a number during migration.