### PR TITLE
V2.3 quendalon

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -14,7 +14,7 @@
 - It is possible again to go to previous topic of a book in scriptorium
 - Missing spell warning is now properly formated in scriptorium
 - Multitopic book reading was not working after a change to the dialog (reader, date, ...)
-- There is no longer an error when you try to read an ability or spell mastery book you are too skilled for.
+- There is no longer an error when you try to read an ability book you are too skilled for.
 
 ## 2.3.0.10, Quendalon, raised by the Fae BF3
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,14 @@
+## 2.3.0.11, Quendalon, raised by the Fae BF4
+
+### Bug fixes
+
+- Fix requisites editing on roll
+- Applied activities can no longer have their type changed.
+- Fixed bug in sanatorium V12 when changing the data.
+- Virtues and flaws are working again on beast sheet
+- Vis source attributes are visible again
+- Quick dialogs (Vitals, Combat, Magic) are now updating when the linked character changes (V12 only)
+
 ## 2.3.0.10, Quendalon, raised by the Fae BF3
 
 ### Bug fixes

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -8,6 +8,13 @@
 - Virtues and flaws are working again on beast sheet
 - Vis source attributes are visible again
 - Quick dialogs (Vitals, Combat, Magic) are now updating when the linked character changes (V12 only)
+- [V12] Changed actor links mechanics since appId of a sheet is only defined on render (instead of constructor).
+- Covenant laborers were wrongly considered servants
+- Covenant teamsters were not considered workers.
+- It is possible again to go to previous topic of a book in scriptorium
+- Missing spell warning is now properly formated in scriptorium
+- Multitopic book reading was not working after a change to the dialog (reader, date, ...)
+- There is no longer an error when you try to read an ability or spell mastery book you are too skilled for.
 
 ## 2.3.0.10, Quendalon, raised by the Fae BF3
 

--- a/module/actor/actor-covenant-sheet.js
+++ b/module/actor/actor-covenant-sheet.js
@@ -86,7 +86,7 @@ export class ArM5eCovenantActorSheet extends ArM5eActorSheet {
 
     for (let person of context.system.inhabitants.magi) {
       if (person.system.linked) {
-        this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
+        // this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
         person.system.yearBorn = person.system.document.system.description.born.value;
       }
 
@@ -100,21 +100,21 @@ export class ArM5eCovenantActorSheet extends ArM5eActorSheet {
 
     for (let person of context.system.inhabitants.companion) {
       if (person.system.linked) {
-        this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
+        // this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
         person.system.yearBorn = person.system.document.system.description.born.value;
       }
     }
 
     for (let person of context.system.inhabitants.turbula) {
       if (person.system.linked) {
-        this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
+        // this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
         person.system.yearBorn = person.system.document.system.description.born.value;
       }
     }
 
     for (let person of context.system.inhabitants.specialists) {
       if (person.system.linked) {
-        this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
+        // this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
         person.system.yearBorn = person.system.document.system.description.born.value;
       }
       context.system.loyalty.modifiers.specialists += person.system.loyaltyGain;
@@ -122,17 +122,17 @@ export class ArM5eCovenantActorSheet extends ArM5eActorSheet {
 
     for (let person of context.system.inhabitants.habitants) {
       if (person.system.linked) {
-        this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
+        // this.actor.apps[person.system.document.sheet.appId] = person.system.document.sheet;
         person.system.yearBorn = person.system.document.system.description.born.value;
       }
       person.system.categoryLabel = CONFIG.ARM5E.covenant.inhabitants[person.system.category].label;
     }
 
-    for (let lab of context.system.labs) {
-      if (lab.system.linked) {
-        this.actor.apps[lab.system.document.sheet.appId] = lab.system.document.sheet;
-      }
-    }
+    // for (let lab of context.system.labs) {
+    //   if (lab.system.linked) {
+    //     this.actor.apps[lab.system.document.sheet.appId] = lab.system.document.sheet;
+    //   }
+    // }
 
     context.system.loyalty.points.modifiersTotal =
       context.system.loyalty.modifiers.livingConditions +
@@ -182,6 +182,49 @@ export class ArM5eCovenantActorSheet extends ArM5eActorSheet {
     log(false, "Covenant-sheet getData");
     log(false, context);
     return context;
+  }
+
+  async _render(force, options = {}) {
+    // Parent class rendering workflow
+    await super._render(force, options);
+
+    // Register the active Application with the referenced Documents
+
+    for (let person of this.actor.system.inhabitants.magi) {
+      if (person.system.linked) {
+        person.system.document.apps[this.appId] = this;
+      }
+    }
+
+    for (let person of this.actor.system.inhabitants.companion) {
+      if (person.system.linked) {
+        person.system.document.apps[this.appId] = this;
+      }
+    }
+
+    for (let person of this.actor.system.inhabitants.turbula) {
+      if (person.system.linked) {
+        person.system.document.apps[this.appId] = this;
+      }
+    }
+
+    for (let person of this.actor.system.inhabitants.specialists) {
+      if (person.system.linked) {
+        person.system.document.apps[this.appId] = this;
+      }
+    }
+
+    for (let person of this.actor.system.inhabitants.habitants) {
+      if (person.system.linked) {
+        person.system.document.apps[this.appId] = this;
+      }
+    }
+
+    for (let lab of this.actor.system.labs) {
+      if (lab.system.linked) {
+        lab.system.document.apps[this.appId] = this;
+      }
+    }
   }
 
   isItemDropAllowed(itemData) {

--- a/module/actor/actor-laboratory-sheet.js
+++ b/module/actor/actor-laboratory-sheet.js
@@ -118,10 +118,10 @@ export class ArM5eLaboratoryActorSheet extends ArM5eActorSheet {
 
     if (context.system.owner && context.system.owner.linked) {
       // Owner
-      this.actor.apps[context.system.owner.document.sheet.appId] =
-        context.system.owner.document.sheet;
+      // this.actor.apps[context.system.owner.document.sheet.appId] =
+      //   context.system.owner.document.sheet;
 
-      context.system.owner.document.apps[this.appId] = this;
+      // context.system.owner.document.apps[this.appId] = this;
 
       context.planning = this.actor.getFlag(ARM5E.SYSTEM_ID, "planning");
       if (context.planning) {
@@ -181,8 +181,8 @@ export class ArM5eLaboratoryActorSheet extends ArM5eActorSheet {
     // Covenant
     if (context.system.covenant) {
       if (context.system.covenant.linked) {
-        this.actor.apps[context.system.covenant.document.sheet.appId] =
-          context.system.covenant.document.sheet;
+        // this.actor.apps[context.system.covenant.document.sheet.appId] =
+        //   context.system.covenant.document.sheet;
         context.edition.aura = "readonly";
         context.planning.modifiers.aura = context.system.auraBonus;
       } else {
@@ -478,7 +478,8 @@ export class ArM5eLaboratoryActorSheet extends ArM5eActorSheet {
       let updateArray = [];
       // if the actor was linked, remove listener
       if (this.actor.system.owner.linked) {
-        delete this.actor.apps[this.actor.system.owner.document.sheet.appId];
+        delete this.actor.apps[this.actor.system.owner.document.sheet?.appId];
+        delete this.actor.system.owner.document.apps[this.appId];
         updateArray.push(await this.actor.system.owner.document.sheet._unbindActor(this.actor));
       }
       let updateData = { "system.owner.value": val };
@@ -884,13 +885,15 @@ export class ArM5eLaboratoryActorSheet extends ArM5eActorSheet {
 
     if (droppedActor._isCharacter()) {
       if (this.actor.system.owner.linked) {
-        delete this.actor.apps[this.actor.system.owner.document.sheet.appId];
+        delete this.actor.system.owner.document.apps[this.appId];
+        delete this.actor.apps[this.actor.system.owner.document.sheet?.appId];
         updateArray.push(await this.actor.system.owner.document.sheet._unbindActor(this.actor));
       }
       updateArray.push(await droppedActor.sheet._bindActor(this.actor));
     } else if (droppedActor.type === "covenant") {
       if (this.actor.system.covenant.linked) {
-        delete this.actor.apps[this.actor.system.covenant.document.sheet.appId];
+        delete this.actor.system.covenant.document.apps[this.appId];
+        delete this.actor.apps[this.actor.system.covenant.document.sheet?.appId];
         await this.actor.system.covenant.document.sheet._unbindActor(this.actor);
       }
       await droppedActor.sheet._bindActor(this.actor);
@@ -925,6 +928,7 @@ export class ArM5eLaboratoryActorSheet extends ArM5eActorSheet {
       updateData["system.owner.actorId"] = null;
       updateData["flags.arm5e.planning"] = await this._resetPlanning("none", true);
     }
+
     return updateData;
   }
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -773,7 +773,8 @@ export class ArM5eActorSheet extends ActorSheet {
       actorData.actor.type == "player" ||
       actorData.actor.type == "npc" ||
       actorData.actor.type == "laboratory" ||
-      actorData.actor.type == "covenant"
+      actorData.actor.type == "covenant" ||
+      actorData.actor.type == "beast"
     ) {
       for (let virtue of actorData.system.virtues) {
         if (virtue.effects.size > 0) {

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -338,12 +338,12 @@ export class ArM5eActorSheet extends ActorSheet {
       }
       context.isDead = this.actor.system.wounds.dead.length > 0;
       context.system.isMagus = this.actor._isMagus();
-      if (context.system.covenant) {
-        if (context.system.covenant.linked) {
-          this.actor.apps[context.system.covenant.document.sheet.appId] =
-            context.system.covenant.document.sheet;
-        }
-      }
+      // if (context.system.covenant) {
+      //   if (context.system.covenant.linked) {
+      //     this.actor.apps[context.system.covenant.document.sheet.appId] =
+      //       context.system.covenant.document.sheet;
+      //   }
+      // }
 
       if (
         context.system?.charType?.value == "magusNPC" ||
@@ -364,12 +364,12 @@ export class ArM5eActorSheet extends ActorSheet {
         context.artsIcons = game.settings.get("arm5e", "artsIcons");
 
         // check whether the character is linked to an existing lab
-        if (context.system.sanctum) {
-          if (context.system.sanctum.linked) {
-            this.actor.apps[context.system.sanctum.document.sheet.appId] =
-              context.system.sanctum.document.sheet;
-          }
-        }
+        // if (context.system.sanctum) {
+        //   if (context.system.sanctum.linked) {
+        //     this.actor.apps[context.system.sanctum.document.sheet.appId] =
+        //       context.system.sanctum.document.sheet;
+        //   }
+        // }
 
         // casting total modifiers
 
@@ -761,6 +761,31 @@ export class ArM5eActorSheet extends ActorSheet {
     return context;
   }
 
+  async _render(force, options = {}) {
+    // Parent class rendering workflow
+    await super._render(force, options);
+
+    // Register the active Application with the referenced Documents
+
+    if (this.actor.system.covenant) {
+      if (this.actor.system.covenant.linked) {
+        this.actor.system.covenant.document.apps[this.appId] = this;
+      }
+    }
+
+    if (this.actor.system.sanctum) {
+      if (this.actor.system.sanctum.linked) {
+        this.actor.system.sanctum.document.apps[this.appId] = this;
+      }
+    }
+
+    if (this.actor.system.owner) {
+      if (this.actor.system.owner.linked) {
+        this.actor.system.owner.document.apps[this.appId] = this;
+      }
+    }
+  }
+
   /**
    * Organize and classify Items for Character sheets.
    *
@@ -935,7 +960,8 @@ export class ArM5eActorSheet extends ActorSheet {
       let updateArray = [];
       // if the actor was linked, remove listener
       if (this.actor.system.covenant.linked) {
-        delete this.actor.apps[this.actor.system.covenant.document.sheet.appId];
+        delete this.actor.apps[this.actor.system.covenant.document.sheet?.appId];
+        delete this.actor.system.covenant.document.apps[this.appId];
         await this.actor.system.covenant.document.sheet._unbindActor(this.actor);
       }
 
@@ -959,7 +985,8 @@ export class ArM5eActorSheet extends ActorSheet {
       let updateArray = [];
       // if the actor was linked, remove listener
       if (this.actor.system.sanctum.linked) {
-        delete this.actor.apps[this.actor.system.sanctum.document.sheet.appId];
+        delete this.actor.apps[this.actor.system.sanctum.document.sheet?.appId];
+        delete this.actor.system.sanctum.document.apps[this.appId];
         updateArray.push(await this.actor.system.sanctum.document.sheet._unbindActor(this.actor));
       }
       let updateData = { "system.sanctum.value": val };
@@ -1851,14 +1878,16 @@ export class ArM5eActorSheet extends ActorSheet {
 
     if (droppedActor.type === "covenant") {
       if (this.actor.system.covenant.linked) {
-        delete this.actor.apps[this.actor.system.owner.document.sheet.appId];
-        updateArray.push(await this.actor.system.owner.document.sheet._unbindActor(this.actor));
+        delete this.actor.apps[this.actor.system.covenant.document.sheet?.appId];
+        delete this.actor.system.covenant.document.apps[this.appId];
+        updateArray.push(await this.actor.system.covenant.document.sheet._unbindActor(this.actor));
         await droppedActor.sheet._bindActor(this.actor);
       }
     } else if (droppedActor.type === "laboratory") {
       if (this.actor.system.sanctum.linked) {
-        delete this.actor.apps[this.actor.system.owner.document.sheet.appId];
-        updateArray.push(await this.actor.system.owner.document.sheet._unbindActor(this.actor));
+        delete this.actor.apps[this.actor.system.owner.sanctum.sheet?.appId];
+        delete this.actor.system.sanctum.document.apps[this.appId];
+        updateArray.push(await this.actor.system.sanctum.document.sheet._unbindActor(this.actor));
       }
       updateArray.push(await droppedActor.sheet._bindActor(this.actor));
     }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1173,18 +1173,18 @@ export class ArM5ePCActor extends Actor {
             system.census.laborers += item.system.number;
             habitants.push(item);
             workersPts += item.system.points;
-            servantPts += item.system.points;
             break;
           case "servants":
             system.census.servants += item.system.number;
             habitants.push(item);
+            servantPts += item.system.points;
             workersPts += item.system.points;
             break;
           case "teamsters":
             system.census.teamsters += item.system.number;
             habitants.push(item);
-            break;
             workersPts += item.system.points;
+            break;
           case "dependants":
             system.census.dependants += item.system.number;
             habitants.push(item);
@@ -1284,6 +1284,22 @@ export class ArM5ePCActor extends Actor {
       }
     }
 
+    // SORTING
+
+    possessions.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    incomingSources.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+
+    weapons.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    armor.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+
+    magi.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    companion.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    specialists.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    turbula.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    habitants.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    horses.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+    livestock.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+
     // BUILD POINTS
 
     system.buildPoints.laboratoryTexts.computed += labTextPts;
@@ -1347,12 +1363,13 @@ export class ArM5ePCActor extends Actor {
       system.census.horses +
       system.census.livestock +
       system.npcInhabitants;
-    system.census.servantsNeeded +=
-      2 * Math.round((system.finances.inhabitantsPoints - workersPts) / 10);
 
-    system.census.teamstersNeeded = Math.round(
-      (system.finances.inhabitantsPoints - servantPts - 2 * system.census.laborers) / 10
-    );
+    // adjust the inhabitant points by removing the workers'
+    let tempTotal = system.finances.inhabitantsPoints - workersPts;
+    system.census.servantsNeeded += 2 * Math.round(tempTotal / 10);
+    // Add the points for these servants to the total
+    tempTotal += servantPts;
+    system.census.teamstersNeeded = Math.round((tempTotal - 2 * system.census.laborers) / 10);
 
     // SAVINGS :
 

--- a/module/arm5e.js
+++ b/module/arm5e.js
@@ -29,7 +29,7 @@ import { log } from "./tools.js";
 
 import { registerSettings } from "./settings.js";
 import { registerTestSuites } from "./tests/tests.js";
-import { StressDie, StressDieInternal } from "./helpers/stressdie.js";
+import { ArsRoll, StressDie, StressDieInternal } from "./helpers/stressdie.js";
 import { UserguideTour } from "./tours/userguide-tour.js";
 
 import {
@@ -118,33 +118,37 @@ Hooks.once("init", async function () {
   // Experimental
   CONFIG.Dice.types.push(StressDie);
   CONFIG.Dice.types.push(StressDieInternal);
+  CONFIG.Dice.ArsRoll = ArsRoll;
   // CONFIG.Dice.types.push(StressDieNoBotchInternal);
   CONFIG.Dice.terms[StressDie.DENOMINATION] = StressDie;
   CONFIG.Dice.terms[StressDieInternal.DENOMINATION] = StressDieInternal;
-  // CONFIG.Dice.terms[StressDieNoBotchInternal.DENOMINATION] = StressDieNoBotchInternal;
-  // instrumenting roll for testing
-  Roll.prototype.botches = 0;
-  Roll.prototype.diviser = 1;
-  Roll.prototype.multiplier = 1;
-  Roll.prototype.offset = 0;
-  Roll.prototype.modifier = function () {
-    if (!this.result) {
-      return 0;
-    }
-    if (this.botches > 0) {
-      return 0;
-    }
-    if (this.dice.length != 1) {
-      log(false, "ERROR: wrong number of dice");
-      return 0;
-    }
+  CONFIG.Dice.rolls[0] = ArsRoll;
+  //CONFIG.Dice.rolls.push(ArsRoll);
 
-    log(
-      false,
-      `DBG: Roll total ${this.total} * ${this.diviser} - (${this.dice[0].total} * ${this.multiplier}) `
-    );
-    return this.total * this.diviser - this.dice[0].total * this.multiplier;
-  };
+  // // CONFIG.Dice.terms[StressDieNoBotchInternal.DENOMINATION] = StressDieNoBotchInternal;
+  // // instrumenting roll for testing
+  // Roll.prototype.botches = 0;
+  // Roll.prototype.diviser = 1;
+  // Roll.prototype.multiplier = 1;
+  // Roll.prototype.offset = 0;
+  // Roll.prototype.modifier = function () {
+  //   if (!this.result) {
+  //     return 0;
+  //   }
+  //   if (this.botches > 0) {
+  //     return 0;
+  //   }
+  //   if (this.dice.length != 1) {
+  //     log(false, "ERROR: wrong number of dice");
+  //     return 0;
+  //   }
+
+  //   log(
+  //     false,
+  //     `DBG: Roll total ${this.total} * ${this.diviser} - (${this.dice[0].total} * ${this.multiplier}) `
+  //   );
+  //   return this.total * this.diviser - this.dice[0].total * this.multiplier;
+  // };
 
   // UI customization
   CONFIG.ui.actors = ArM5eActorsDirectory;
@@ -508,6 +512,10 @@ Hooks.on("renderDialog", (dialog, html) => {
 
 Hooks.on("renderChatMessage", (message, html, data) =>
   Arm5eChatMessage.addChatListeners(message, html, data)
+);
+
+Hooks.on("createChatMessage", (message, html, data) =>
+  Arm5eChatMessage.enrichChatMessage(message, html, data)
 );
 
 // On Apply an ActiveEffect that uses a CUSTOM application mode.

--- a/module/dice.js
+++ b/module/dice.js
@@ -3,6 +3,7 @@ import { checkTargetAndCalculateResistance } from "./helpers/magic.js";
 import { log, putInFoldableLink, putInFoldableLinkWithAnimation, sleep } from "./tools.js";
 import { ARM5E } from "./config.js";
 import { showRollResults } from "./helpers/chat.js";
+import { ArsRoll } from "./helpers/stressdie.js";
 let mult = 1;
 
 /**
@@ -34,7 +35,7 @@ async function simpleDie(actor, type = "OPTION", callBack) {
   if (rollInfo.magic.divide > 1) {
     formula = "(1D10+" + rollInfo.formula + ")/" + rollInfo.magic.divide;
   }
-  const dieRoll = new Roll(formula, actor.system);
+  const dieRoll = new ArsRoll(formula, actor.system);
   let tmp = await dieRoll.roll();
 
   let rollMode = game.settings.get("core", "rollMode");
@@ -534,7 +535,7 @@ function newLineSub(msg) {
 
 async function CheckBotch(botchDice, offset) {
   let rollCommand = String(botchDice).concat("d10cf=10");
-  const botchRoll = new Roll(rollCommand);
+  const botchRoll = new ArsRoll(rollCommand);
   await botchRoll.roll();
   botchRoll.offset = offset;
   botchRoll.botches = botchRoll.total;
@@ -613,7 +614,7 @@ async function explodingRoll(actorData, rollOptions = {}, botchNum = -1) {
         game.dice3d.showForRoll(dieRoll); //, user, synchronize, whisper, blind, chatMessageID, speaker)
       }
       if (rollOptions.noBotch) {
-        let output_roll = new Roll(actorData.rollInfo.formula.toString(), {}, options);
+        let output_roll = new ArsRoll(actorData.rollInfo.formula.toString(), {}, options);
         output_roll.data = {};
         return await output_roll.evaluate(options);
       }
@@ -691,7 +692,7 @@ export async function createRoll(rollFormula, mult, divide, options = {}) {
   if (Number.parseInt(divide) > 1) {
     rollInit = `( ${rollInit} ) / ${divide}`;
   }
-  let output_roll = new Roll(rollInit, {}, options);
+  let output_roll = new ArsRoll(rollInit, {}, options);
   output_roll.offset = rollFormula;
   output_roll.multiplier = mult;
   output_roll.diviser = divide;
@@ -731,7 +732,7 @@ async function noRoll(actor, mode, callback, roll) {
   if (rollInfo.magic.divide > 1) {
     formula += ` / ${rollInfo.magic.divide}`;
   }
-  const dieRoll = new Roll(formula, actor.system);
+  const dieRoll = new ArsRoll(formula, actor.system);
   dieRoll.diviser = rollInfo.magic.divide;
   let tmp = await dieRoll.roll();
   const message = await tmp.toMessage(

--- a/module/helpers/chat.js
+++ b/module/helpers/chat.js
@@ -1,4 +1,5 @@
 import { log, putInFoldableLink, putInFoldableLinkWithAnimation } from "../tools.js";
+import { ArsRoll } from "./stressdie.js";
 
 export function showRollResults(actor, type) {
   let showRolls = game.settings.get("arm5e", "showRolls");
@@ -18,6 +19,15 @@ function showRollFormulas(actor, type) {
     (type === "player" && ["ALL", "PLAYERS"].includes(showFormulas)) ||
     "ALL" == showFormulas
   );
+}
+
+export async function enrichChatMessage(message, html, data) {
+  // if (message.flags.arm5e === undefined && message.rolls.length) {
+  //   await message.setFlag("arm5e", {
+  //     type: type,
+  //     actorType: actor.type // for if the actor is deleted
+  //   });
+  // }
 }
 
 export function addChatListeners(message, html, data) {
@@ -207,7 +217,7 @@ async function useConfidence(ev) {
 
       log(false, flavor);
       let newContent = parseFloat(total) + bonus;
-      const dieRoll = new Roll(newContent.toString(10));
+      const dieRoll = new ArsRoll(newContent.toString(10));
       await dieRoll.evaluate();
       let msgData = {};
       msgData.speaker = message.speaker;

--- a/module/helpers/combat.js
+++ b/module/helpers/combat.js
@@ -41,7 +41,6 @@ export class QuickCombat extends FormApplication {
   constructor(data, options) {
     super(data, options);
 
-    this.object.actor.apps[this.appId] = this;
     Hooks.on("closeApplication", (app, html) => this.onClose(app));
   }
   /** @override */
@@ -55,6 +54,14 @@ export class QuickCombat extends FormApplication {
       submitOnChange: true,
       closeOnSubmit: false
     });
+  }
+
+  async _render(force, options = {}) {
+    // Parent class rendering workflow
+    await super._render(force, options);
+
+    // Register the active Application with the referenced Documents
+    this.object.actor.apps[this.appId] = this;
   }
 
   onClose(app) {
@@ -105,7 +112,7 @@ export class QuickVitals extends FormApplication {
   constructor(data, options) {
     super(data, options);
 
-    this.object.actor.apps[this.appId] = this;
+    // this.object.actor.apps[this.appId] = this;
     Hooks.on("closeApplication", (app, html) => this.onClose(app));
   }
   /** @override */
@@ -119,6 +126,14 @@ export class QuickVitals extends FormApplication {
       submitOnChange: true,
       closeOnSubmit: false
     });
+  }
+
+  async _render(force, options = {}) {
+    // Parent class rendering workflow
+    await super._render(force, options);
+
+    // Register the active Application with the referenced Documents
+    this.object.actor.apps[this.appId] = this;
   }
 
   onClose(app) {

--- a/module/helpers/magic.js
+++ b/module/helpers/magic.js
@@ -192,7 +192,6 @@ export class QuickMagic extends FormApplication {
     super(data, options);
     this.object.technique = "cr";
     this.object.form = "an";
-    this.object.actor.apps[this.appId] = this;
     Hooks.on("closeApplication", (app, html) => this.onClose(app));
   }
   /** @override */
@@ -206,6 +205,14 @@ export class QuickMagic extends FormApplication {
       submitOnChange: true,
       closeOnSubmit: false
     });
+  }
+
+  async _render(force, options = {}) {
+    // Parent class rendering workflow
+    await super._render(force, options);
+
+    // Register the active Application with the referenced Documents
+    this.object.actor.apps[this.appId] = this;
   }
 
   onClose(app) {

--- a/module/helpers/rollWindow.js
+++ b/module/helpers/rollWindow.js
@@ -7,6 +7,7 @@ import { ArM5ePCActor } from "../actor/actor.js";
 import { setAgingEffects, agingCrisis } from "./long-term-activities.js";
 import { exertSelf } from "./combat.js";
 import { getDataset, log } from "../tools.js";
+import { ArM5eItem } from "../item/item.js";
 
 // below is a bitmap
 const ROLL_MODES = {

--- a/module/helpers/stressdie.js
+++ b/module/helpers/stressdie.js
@@ -33,7 +33,7 @@ export class StressDie extends Die {
       this.number = this.options.ddd;
       this._evaluated = false;
       this.modifiers = ["cs=10"];
-      super.evaluate();
+      await super.evaluate();
       return this;
     }
     this.explode("x=1");

--- a/module/helpers/stressdie.js
+++ b/module/helpers/stressdie.js
@@ -9,6 +9,66 @@ export class ArsRoll extends Roll {
     this.multiplier = 1;
     this.offset = 0;
   }
+
+  modifier() {
+    if (!this.result) {
+      return 0;
+    }
+    if (this.botches > 0) {
+      return 0;
+    }
+    if (this.dice.length != 1) {
+      log(false, "ERROR: wrong number of dice");
+      return 0;
+    }
+
+    log(
+      false,
+      `DBG: Roll total ${this.total} * ${this.diviser} - (${this.dice[0].total} * ${this.multiplier}) `
+    );
+    return this.total * this.diviser - this.dice[0].total * this.multiplier;
+  }
+
+  /**
+   * Transform a Roll instance into a ChatMessage, displaying the roll result.
+   * This function can either create the ChatMessage directly, or return the data object that will be used to create.
+   *
+   * @param {object} messageData          The data object to use when creating the message
+   * @param {options} [options]           Additional options which modify the created message.
+   * @param {string} [options.rollMode]   The template roll mode to use for the message from CONFIG.Dice.rollModes
+   * @param {boolean} [options.create=true]   Whether to automatically create the chat message, or only return the
+   *                                          prepared chatData object.
+   * @returns {Promise<ChatMessage|object>} A promise which resolves to the created ChatMessage document if create is
+   *                                        true, or the Object of prepared chatData otherwise.
+   */
+  // async toMessage(messageData = {}, { rollMode, create = true } = {}) {
+  //   log(false, "TO_MESSAGE");
+  //   super.toMessage(messageData, options);
+  // if ( rollMode === "roll" ) rollMode = undefined;
+  // rollMode ||= game.settings.get("core", "rollMode");
+
+  // // Perform the roll, if it has not yet been rolled
+  // if ( !this._evaluated ) await this.evaluate({allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND});
+
+  // // Prepare chat data
+  // messageData = foundry.utils.mergeObject({
+  //   user: game.user.id,
+  //   content: String(this.total),
+  //   sound: CONFIG.sounds.dice
+  // }, messageData);
+  // messageData.rolls = [this];
+
+  // // Either create the message or just return the chat data
+  // const cls = getDocumentClass("ChatMessage");
+  // const msg = new cls(messageData);
+
+  // // Either create or return the data
+  // if ( create ) return cls.create(msg.toObject(), { rollMode });
+  // else {
+  //   msg.applyRollMode(rollMode);
+  //   return msg.toObject();
+  // }
+  // }
 }
 
 export class StressDie extends Die {
@@ -43,16 +103,21 @@ export class StressDie extends Die {
   get total() {
     if (!this._evaluated) return null;
     if (this.modifiers.length > 0) return 1 - super.total;
-    return this.results.reduce((t, r, i, a) => {
+    const res = this.results.reduce((t, r, i, a) => {
+      log(false, `DBG: total.reduce res=${r.result}, i=${i} * t=${t} ; ${r.active}) `);
       if (!r.active) return t;
       if (i === 0 && r.result === 10) {
         return 0;
       }
-      if (i === 0 && r.result === 1) return 2;
+      if (i === 0 && r.result === 1) {
+        return 2;
+      }
       if (i === 0 && r.result !== 10 && r.result !== 1) return r.result;
       if (r.result === 1) return t * 2;
       return t * r.result;
     }, 0);
+    log(false, `DBG: total=${res}`);
+    return res;
   }
 
   /** @inheritdoc */

--- a/module/item/item-diary-sheet.js
+++ b/module/item/item-diary-sheet.js
@@ -152,6 +152,7 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
     if (this.actor.system.pendingCrisis) {
       context.system.applyError = "arm5e.notification.pendingCrisis";
       context.system.disabled = "disabled";
+      context.activityState = "disabled";
       context.system.applyPossible = false;
       return context;
     }
@@ -339,6 +340,10 @@ export class ArM5eItemDiarySheet extends ArM5eItemSheet {
     }
     context.totalQuality =
       context.system.sourceQuality + context.system.sourceModifier + context.system.sourceBonus;
+
+    if (context.system.disabled === "disabled") {
+      context.activityState = "disabled";
+    }
     log(false, "ITEM-DIARY-sheet get data");
     log(true, context);
     return context;

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -263,6 +263,7 @@ export class ArM5eItemSheet extends ItemSheet {
             break;
           case "player":
           case "npc":
+          case "beast":
             context.config.virtueFlawTypes.available = {
               ...context.config.virtueFlawTypes.character,
               ...context.config.virtueFlawTypes.all

--- a/module/schemas/commonSchemas.js
+++ b/module/schemas/commonSchemas.js
@@ -148,7 +148,7 @@ export const CostField = (value = "n-a", coeff = 1, pounds = 1) =>
         required: false,
         blank: false,
         initial: value,
-        choices: Object.keys(ARM5E.item.costs)
+        choices: Object.keys(CONFIG.ARM5E.item.costs)
       }),
       mythicPounds: new fields.NumberField({
         required: false,
@@ -175,9 +175,11 @@ export const CostField = (value = "n-a", coeff = 1, pounds = 1) =>
     { required: false, initial: { value: "n-a", mythicPounds: 0 } }
   );
 
-export const possibleRanges = Object.keys(ARM5E.magic.ranges).filter((r) => !r.disabled);
-export const possibleTargets = Object.keys(ARM5E.magic.targets).filter((r) => !r.disabled);
-export const possibleDurations = Object.keys(ARM5E.magic.durations).filter((r) => !r.disabled);
+// export const possibleRanges = Object.keys(CONFIG.ARM5E.magic.ranges).filter((r) => !r.disabled);
+// export const possibleTargets = Object.keys(CONFIG.ARM5E.magic.targets).filter((r) => !r.disabled);
+// export const possibleDurations = Object.keys(CONFIG.ARM5E.magic.durations).filter(
+//   (r) => !r.disabled
+// );
 export const boolOption = (val = false, nullable = false) =>
   new fields.BooleanField({ required: false, initial: val, nullable: nullable });
 export const baseDescription = (initial = "") =>
@@ -251,7 +253,7 @@ export const RealmField = (initial = "mundane") => {
     required: false,
     blank: false,
     initial: initial,
-    choices: Object.keys(ARM5E.realmsExt)
+    choices: Object.keys(CONFIG.ARM5E.realmsExt)
   });
 };
 
@@ -263,7 +265,7 @@ export const SpellAttributes = () => {
           required: true,
           blank: false,
           initial: "personal",
-          choices: possibleRanges
+          choices: Object.keys(CONFIG.ARM5E.magic.ranges).filter((r) => !r.disabled)
         })
       },
       { required: false, blank: false, initial: { value: "personal" } }
@@ -274,7 +276,7 @@ export const SpellAttributes = () => {
           required: true,
           blank: false,
           initial: "moment",
-          choices: possibleDurations
+          choices: Object.keys(CONFIG.ARM5E.magic.durations).filter((r) => !r.disabled)
         })
       },
       { required: false, blank: false, initial: { value: "moment" } }
@@ -285,7 +287,7 @@ export const SpellAttributes = () => {
           required: true,
           blank: false,
           initial: "ind",
-          choices: possibleTargets
+          choices: Object.keys(CONFIG.ARM5E.magic.targets).filter((r) => !r.disabled)
         })
       },
       { required: false, blank: false, initial: { value: "ind" } }
@@ -334,7 +336,7 @@ export const SeasonField = (season = "spring") =>
     required: false,
     blank: false,
     initial: season,
-    choices: Object.keys(ARM5E.seasons)
+    choices: Object.keys(CONFIG.ARM5E.seasons)
   });
 
 export const XpField = () =>
@@ -374,7 +376,7 @@ export const hermeticForm = () =>
     required: false,
     blank: false,
     initial: "an",
-    choices: Object.keys(ARM5E.magic.forms)
+    choices: Object.keys(CONFIG.ARM5E.magic.forms)
   });
 
 export const hermeticTechnique = () =>
@@ -382,7 +384,7 @@ export const hermeticTechnique = () =>
     required: false,
     blank: false,
     initial: "cr",
-    choices: Object.keys(ARM5E.magic.techniques)
+    choices: Object.keys(CONFIG.ARM5E.magic.techniques)
   });
 
 export const authorship = () => {

--- a/module/schemas/minorItemsSchemas.js
+++ b/module/schemas/minorItemsSchemas.js
@@ -13,13 +13,13 @@ import {
 import { EnchantmentExtension, ItemState } from "./enchantmentSchema.js";
 const fields = foundry.data.fields;
 
-export const possibleReputationTypes = Object.keys(ARM5E.reputations);
+// export const possibleReputationTypes = Object.keys(ARM5E.reputations);
 
-const virtueFlawTypes = Object.keys(ARM5E.virtueFlawTypes.character)
-  .concat(Object.keys(ARM5E.virtueFlawTypes.laboratory))
-  .concat(Object.keys(ARM5E.virtueFlawTypes.covenant))
-  .concat("Special")
-  .concat("other");
+// const virtueFlawTypes = Object.keys(ARM5E.virtueFlawTypes.character)
+//   .concat(Object.keys(ARM5E.virtueFlawTypes.laboratory))
+//   .concat(Object.keys(ARM5E.virtueFlawTypes.covenant))
+//   .concat("Special")
+//   .concat("other");
 export class VirtueFlawSchema extends foundry.abstract.DataModel {
   // TODO remove in V11
   static _enableV10Validation = true;
@@ -31,7 +31,11 @@ export class VirtueFlawSchema extends foundry.abstract.DataModel {
         required: false,
         blank: false,
         initial: "general",
-        choices: virtueFlawTypes
+        choices: Object.keys(ARM5E.virtueFlawTypes.character)
+          .concat(Object.keys(ARM5E.virtueFlawTypes.laboratory))
+          .concat(Object.keys(ARM5E.virtueFlawTypes.covenant))
+          .concat("Special")
+          .concat("other")
       }),
       impact: new fields.SchemaField(
         {
@@ -116,6 +120,11 @@ export class VirtueFlawSchema extends foundry.abstract.DataModel {
     }
 
     // special cases
+    const virtueFlawTypes = Object.keys(ARM5E.virtueFlawTypes.character)
+      .concat(Object.keys(ARM5E.virtueFlawTypes.laboratory))
+      .concat(Object.keys(ARM5E.virtueFlawTypes.covenant))
+      .concat("Special")
+      .concat("other");
     if (itemData.system.type === "Social Status") {
       updateData["system.type"] = "social";
     } else if (!virtueFlawTypes.includes(itemData.system.type)) {
@@ -208,7 +217,7 @@ export class ReputationSchema extends foundry.abstract.DataModel {
         required: false,
         blank: false,
         initial: "local",
-        choices: possibleReputationTypes
+        choices: Object.keys(ARM5E.reputations)
       })
     };
   }

--- a/module/tools/med-history.js
+++ b/module/tools/med-history.js
@@ -16,8 +16,8 @@ export class MedicalHistory extends FormApplication {
       {}
     ); // data, options
 
-    actor.apps[medHist.appId] = medHist;
     const res = await medHist.render(true);
+    actor.apps[medHist.appId] = medHist;
   }
   /** @override */
   static get defaultOptions() {

--- a/module/tools/sanatorium.js
+++ b/module/tools/sanatorium.js
@@ -35,8 +35,8 @@ export class Sanatorium extends FormApplication {
   static async createDialog(actor) {
     // const dialogData = { patient: actor };
     const sanatorium = new Sanatorium(actor, {}, {}); // data, options
-    actor.apps[sanatorium.appId] = sanatorium;
     const res = await sanatorium.render(true);
+    actor.apps[sanatorium.appId] = sanatorium;
   }
   /** @override */
   static get defaultOptions() {

--- a/module/tools/scriptorium.js
+++ b/module/tools/scriptorium.js
@@ -442,9 +442,11 @@ export class Scriptorium extends FormApplication {
         case "mastery": {
           if (context.reading.reader.spells.length === 0) {
             context.ui.editItem = "disabled";
-            context.ui.reading.warning.push(game.i18n.format("arm5e.scriptorium.msg.missingItem"), {
-              item: game.i18n.localize("arm5e.sheet.spell")
-            });
+            context.ui.reading.warning.push(
+              game.i18n.format("arm5e.scriptorium.msg.missingItem", {
+                item: game.i18n.localize("arm5e.sheet.spell")
+              })
+            );
             context.ui.reading.error = true;
           } else {
             if (!context.reading.reader.spell) {
@@ -460,7 +462,7 @@ export class Scriptorium extends FormApplication {
           break;
         }
         default:
-          context.ui.warning.push("Error");
+          context.ui.reading.warning.push("Error");
           context.ui.reading.error = true;
           break;
       }
@@ -828,7 +830,9 @@ export class Scriptorium extends FormApplication {
     html.find(".section-handle").click(this._handle_section.bind(this));
 
     html.find(".next-topic").click(async (event) => this._changeCurrentTopic("reading", event, 1));
-    html.find(".previous-topic").click(async (event) => this._changeCurrentTopic("reading", -1));
+    html
+      .find(".previous-topic")
+      .click(async (event) => this._changeCurrentTopic("reading", event, -1));
     html.find(".next-topicToCopy").click(async (event) => this._changeTopic("copying", event, 1));
     html
       .find(".previous-topicToCopy")
@@ -1709,11 +1713,17 @@ export class Scriptorium extends FormApplication {
   async _updateObject(event, formData) {
     const expanded = foundry.utils.expandObject(formData);
 
+    if (expanded.reading?.book?.system?.topics) {
+      const topics = this.object.reading.book.system.topics;
+      foundry.utils.mergeObject(topics, expanded.reading.book.system.topics);
+      delete expanded.reading.book.system.topics;
+    }
     if (expanded.writing?.book?.system?.topics) {
       const topics = this.object.writing.book.system.topics;
       foundry.utils.mergeObject(topics, expanded.writing.book.system.topics);
       delete expanded.writing.book.system.topics;
     }
+
     if (expanded.copying?.books) {
       const bookIndexes = Object.keys(expanded.copying.books);
       for (const index of bookIndexes) {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "2.3.0.10",
+  "version": "2.3.0.11",
   "compatibility": {
     "minimum": "10.290",
     "verified": "12.330"

--- a/templates/actor/actor-beast-sheet.html
+++ b/templates/actor/actor-beast-sheet.html
@@ -88,7 +88,7 @@
     </nav>
 
     {{!-- Sheet Body --}}
-    <section class="sheet-body">
+    <section class="sheet-body" style="min-height: 245px;">
       {{!-- Description Tab --}}
       <div class="tab description" data-group="primary" data-tab="description">
         <nav class="arm5eSubTabs desc-tabs tabs" data-group="desc-secondary">

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -60,6 +60,14 @@
               <input name="system.covenant.name" class="covenant-link" type="text" value="{{system.covenant.value}}"
                 data-dtype="String" style="margin-left: 8px" />
             </h2>
+            <div style="padding-top: 10px; padding-left: 3px; max-width:15px;">
+              {{#if (eq system.covenant.linked true)}}
+                <a class="flexrow0 actor-link" title="Linked to covenant" data-actorid="{{system.covenant.actorId}}"><i
+                    class="fas fa-link fa-sm"></i></a>
+              {{else}}
+                <a class="flexrow0" title="Not linked to covenant"><i class="fas fa-unlink fa-sm"></i></a>
+              {{/if}}
+            </div>
           {{/if}} {{#if (eq system.charType.value "magusNPC")}}
             <span class="covenantname flexrow" style="padding-top: 4px">
               <label for="system.house.value" class="bold flex0"

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -167,7 +167,7 @@
     </nav>
 
     {{!-- Sheet Body --}}
-    <section class="sheet-body">
+    <section class="sheet-body" style="min-height: 245px;">
       {{!-- Description Tab --}}
       <div class="tab description" data-group="primary" data-tab="description">
         <nav class="arm5eSubTabs desc-tabs tabs" data-group="desc-secondary">

--- a/templates/actor/actor-pc-sheet.html
+++ b/templates/actor/actor-pc-sheet.html
@@ -147,7 +147,7 @@
     </nav>
 
     {{!-- Sheet Body --}}
-    <section class="sheet-body">
+    <section class="sheet-body" style="min-height: 245px;">
       {{!-- Description Tab --}}
       <div class="tab description" data-group="primary" data-tab="description">
         <nav class="arm5eSubTabs desc-tabs tabs" data-group="desc-secondary">

--- a/templates/generic/parts/scriptorium-reading.html
+++ b/templates/generic/parts/scriptorium-reading.html
@@ -178,24 +178,27 @@
           <div class="scriptorium resource"></div>
           <div class="scriptorium resource"></div>
           {{#if (eq reading.book.currentTopic.category "ability")}}
-            <div class="scriptorium resource">
-              <label for="reading.reader.ability" class="header-label">{{localize "arm5e.sheet.abilities"}}</label>
-              <select name="reading.reader.ability" data-dtype="String" class="ability-key" {{ui.editItem}}>
-                {{selectOptions reading.reader.abilities selected=reading.reader.ability labelAttr="name" 
+            {{#unless ui.reading.error}}
+              <div class="scriptorium resource">
+                <label for="reading.reader.ability" class="header-label">{{localize "arm5e.sheet.abilities"}}</label>
+                <select name="reading.reader.ability" data-dtype="String" class="ability-key" {{ui.editItem}}>
+                  {{selectOptions reading.reader.abilities selected=reading.reader.ability labelAttr="name" 
                 nameAttr="_id" valueAttr="_id"}}
-              </select>
-            </div>
-
+                </select>
+              </div>
+            {{/unless}}
             <div class="scriptorium resource"></div>
           {{/if}}
           {{#if (eq reading.book.currentTopic.category "mastery")}}
-            <div class="scriptorium resource">
-              <label for="reading.reader.spell" class="header-label">{{localize "arm5e.sheet.spells"}}</label>
-              <select name="reading.reader.spell" data-dtype="String" class="ability-key" {{ui.editItem}}>
-                {{selectOptions reading.reader.spells selected=reading.reader.spell labelAttr="name" 
+            {{#unless ui.reading.error}}
+              <div class="scriptorium resource">
+                <label for="reading.reader.spell" class="header-label">{{localize "arm5e.sheet.spells"}}</label>
+                <select name="reading.reader.spell" data-dtype="String" class="ability-key" {{ui.editItem}}>
+                  {{selectOptions reading.reader.spells selected=reading.reader.spell labelAttr="name" 
                  nameAttr="id" valueAttr="id"}}
-              </select>
-            </div>
+                </select>
+              </div>
+            {{/unless}}
           {{/if}}
           <ul>
             {{#each ui.reading.warning }}

--- a/templates/generic/sanatorium.html
+++ b/templates/generic/sanatorium.html
@@ -28,9 +28,8 @@
       <div class="resource-content flexrow">
         <div class="resource-content flexrow flex-center flex-between margintop6">
           <label for="curSeason" class="smallTitle" style="font-size:16pt">{{localize "arm5e.sheet.season"}}</label>
-          <input type="text" name="curSeason" readonly value="{{curSeasonLabel}}" data-dtype="String"
-            class="sanatorium change-season resource-focus" style="
-      font-size: 18pt;" />
+          <input type="text" readonly value="{{curSeasonLabel}}" data-dtype="String" class="sanatorium change-season"
+            style="font-size: 18pt;" />
         </div>
         <div class="resource-content flexrow flex-center flex-between margintop6">
           <label for="curYear" class="smallTitle" style="font-size:16pt">{{localize "arm5e.sheet.year"}}</label>

--- a/templates/item/item-visSourcesCovenant-sheet.html
+++ b/templates/item/item-visSourcesCovenant-sheet.html
@@ -64,7 +64,7 @@
     {{!-- Attributes Tab --}}
     <div class="tab attributes" data-group="primary" data-tab="attributes">
       <label for="system.form" class="header-label">{{localize "arm5e.sheet.physicalForm"}}</label>
-      {{editor system.enrichedForm target="system.form" button=true owner=owner engine="prosemirror" editable=editable}}
+      {{editor enrichedForm target="system.form" button=true owner=owner engine="prosemirror" editable=editable}}
     </div>
 
     {{!-- Description Tab --}}


### PR DESCRIPTION
## 2.3.0.11, Quendalon, raised by the Fae BF4

### Bug fixes

- Fix requisites editing on roll
- Applied activities can no longer have their type changed.
- Fixed bug in sanatorium V12 when changing the data.
- Virtues and flaws are working again on beast sheet
- Vis source attributes are visible again
- Quick dialogs (Vitals, Combat, Magic) are now updating when the linked character changes (V12 only)
- [V12] Changed actor links mechanics since appId of a sheet is only defined on render (instead of constructor).
- Covenant laborers were wrongly considered servants
- Covenant teamsters were not considered workers.
- It is possible again to go to previous topic of a book in scriptorium
- Missing spell warning is now properly formated in scriptorium
- Multitopic book reading was not working after a change to the dialog (reader, date, ...)
- There is no longer an error when you try to read an ability book you are too skilled for.