### PR TITLE
V2.4.0 radislav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ packs/**
 website/UserGuide/.obsidian
 arm5e.lock
 CommitChangeNotes.md
-
+*.json.bak
 .vscode/settings.json
 *.code-workspace

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,22 @@
+## 2.4.0.25, Radislav agrees with Quendalon
+
+### V13 compatibility
+
+### Features & changes
+
+- Various improvements to chat messages design.
+- New active effects:
+  - Alternate Arts XP bonus
+  - Specific form magic resistance (not cumulative with Parma)
+- [Technical] Mnemonics reorganization - WIP
+
+## Bug fixes
+
+- Parma is now properly multiplied by 5 when computing magic resistance during contest.
+- It is now possible to edit the number of warping points when triggering a Twilight manually
+- Confidence spending was not allowed for Twilight control and understanding.
+- Virtues and flaws icons were reduced to size 0
+
 ## 2.4.0.24, Radislav the guy with the accent
 
 ### V13 compatibility

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,18 @@
+## 2.4.0.24, Radislav the guy with the accent
+
+### V13 compatibility
+
+- Fix Arcane implementation rolls
+- The V13 disclaimer at login is no longer persistent
+
+## Bug fixes
+
+- Default difficulty of a roll chat message is now 0 instead of 1
+- Removed the "versus <difficulty>" in the roll message in case of a botch.
+- Confidence prompt icon will now appear with all types of characters.
+- Confidence prompt icon will appear even if there is no consequence to the roll (fatigue, wounds,...)
+- The loss of warping points will appear only once on the chat message
+
 ## 2.4.0.23, Radislav am Polanach
 
 ### Compatibility

--- a/lang/en.json
+++ b/lang/en.json
@@ -54,6 +54,128 @@
     }
   },
   "arm5e": {
+    "activeEffect": {
+      "add": "Add {score} to {value}",
+      "bonuses": {
+        "penetration": "Penetration bonus"
+      },
+      "changeMode": "Change Mode",
+      "changeValue": "Effect Value",
+      "info": {
+        "noedit": "Note: Active effect creation is not possible if the Item is owned by an Actor, edit the original or make a copy in your world to edit."
+      },
+      "mode_0": "Custom",
+      "mode_1": "Multiply",
+      "mode_2": "Add",
+      "mode_3": "Downgrade",
+      "mode_4": "Upgrade",
+      "mode_5": "Override",
+      "multiply": "Multiply {type} by ",
+      "new": "New effect",
+      "section": {
+        "inactive": "Inactive effects",
+        "passive": "Passive effects",
+        "temporary": "Temporary effects"
+      },
+      "subtypes": {
+        "attackRoll": "Attack rolls",
+        "auraLevel": "Aura's level",
+        "auraRealm": "Realm of aura",
+        "buildings": "Buildings",
+        "combatRoll": "Combat rolls",
+        "consumables": "Consumables",
+        "defRoll": "Defence rolls",
+        "fatigueTotal": "Fatigue total",
+        "formMagicRoll": "Formulaic magic rolls",
+        "inhabitantPoints": "Inhabitant points",
+        "initRoll": "Initiative rolls",
+        "inventSpell": "Invent spell",
+        "labText": "Laboratory texts",
+        "laboratories": "Laboratories",
+        "laborers": "Laborers",
+        "labs": "Laboratories",
+        "learnSpell": "Learn spell",
+        "library": "Library",
+        "magicItems": "MagicItems",
+        "magicResistance": "Magic resistance",
+        "magicRoll": "Magic rolls",
+        "money": "Money",
+        "none": "None",
+        "provisions": "Provisions",
+        "ritualFatigueCancelled": "Ritual fatigue levels cancelled",
+        "servants": "Servants",
+        "specialists": "Specialists",
+        "spellFatigueThreshold": "Spell fatigue threshold",
+        "spontDivider": "Spont. magic divider",
+        "spontDividerNoFatigue": "Spont. magic divider no fatigue",
+        "spontMagicRoll": "Spontaneous magic rolls",
+        "teamsters": "Teamsters",
+        "turbula": "Turbula",
+        "vis": "Vis",
+        "wages": "Wages",
+        "weapons": "Weapons & Armor",
+        "woundsTotal": "Wounds total",
+        "writingMaterials": "Writting materials",
+        "xpcoeff": "Xp multiplier",
+        "xpmod": "Xp bonus"
+      },
+      "type": {
+        "covenantBuildPoint": "Covenant's build points",
+        "covenantInhabitants": "Covenant's inhabitants",
+        "spellcasting": "Spellcasting",
+        "yearlyExpenses": "Covenant's expenses",
+        "yearlySavings": {
+          "magic": "Covenant's savings with magic",
+          "mundane": "Covenant's savings mundane"
+        }
+      },
+      "types": {
+        "AlternateArtBonus": "Bonus alternate Arts",
+        "AlternateArtXPBonus": "Bonus alternate Arts XP",
+        "academicAbilitiesAffinity": "Affinity Academic abilities (xp)",
+        "academicAbilitiesBonus": "Bonus Academic abilities",
+        "academicAbilitiesXPBonus": "Bonus to Academic abilities XP",
+        "affinityAlternateArt": "Affinity alternate arts (xp)",
+        "arcaneAbilitiesAffinity": "Affinity Arcane abilities (xp)",
+        "arcaneAbilitiesBonus": "Bonus Arcane abilities",
+        "arcaneAbilitiesXPBonus": "Bonus to Arcane abilities XP",
+        "arts": {
+          "affinity": "Art affinity",
+          "deficiency": "Art deficiency"
+        },
+        "characteristicBoost": "Characteristic's boost",
+        "characteristics": "Characteristics",
+        "fatigue": "Fatigue",
+        "formMagicResistance": "Magical resistance to Form",
+        "formResistance": "Natural resistance",
+        "generalAbilitiesAffinity": "Affinity General abilities (xp)",
+        "generalAbilitiesBonus": "Bonus General abilities",
+        "generalAbilitiesXPBonus": "Bonus to General abilities XP",
+        "labActivity": "Character laboratory activity",
+        "laboratoryAttr": "Laboratory's attributes",
+        "laboratorySpec": "Laboratory's specialty",
+        "martialAbilitiesAffinity": "Affinity Martial abilities (xp)",
+        "martialAbilitiesBonus": "Bonus Martial abilities",
+        "martialAbilitiesXPBonus": "Bonus to Martial abilities XP",
+        "mysteryAbilitiesAffinity": "Affinity Mysteries abilities (xp)",
+        "mysteryAbilitiesBonus": "Bonus Mysteries abilities",
+        "mysteryAbilitiesXPBonus": "Bonus to Mystery abilities XP",
+        "nullEffect": "Null effect",
+        "optional": "Optional bonus",
+        "qualityAbilityBoost": "Quality - Ability boost",
+        "realmAlignment": "Realm alignment",
+        "realmSusceptibility": "Realm susceptibility",
+        "roll": {
+          "optional": "Optional roll bonus"
+        },
+        "spellmastery": "Spell mastery",
+        "supernaturalAbilitiesAffinity": "Affinity Supernat. abil. (xp)",
+        "supernaturalAbilitiesBonus": "Bonus Supernat. abilities",
+        "supernaturalAbilitiesXPBonus": "Bonus to Supernat. abilities XP",
+        "vitals": "Vitals",
+        "wounds": "Wounds"
+      }
+    },
     "activity": {
       "activity": "Activity",
       "adventuring": "Adventuring",
@@ -252,6 +374,12 @@
         "clearAura": "Clear Aura",
         "setAura": "Configure Aura"
       }
+    },
+    "chat": {
+      "contestOfMagic": "Contest of magic",
+      "contestOfMagicWith": "Contest of magic with {name}",
+      "otherMagicResistance": "Other Magic resistance",
+      "totalMagicResistance": "Magic resistance total"
     },
     "combat": {
       "damage": {
@@ -713,6 +841,20 @@
         "name": "Abilities"
       }
     },
+    "realm": {
+      "divine": "Divine",
+      "faeric": "Faerie",
+      "infernal": "Infernal",
+      "label": "Realm",
+      "magic": "Magical",
+      "mundane": "Mundane",
+      "nightModifier": "Night Modifier",
+      "susceptible": {
+        "impact": "Due to susceptibility to {realm}, divided by {divisor}"
+      },
+      "visible": "Visible",
+      "visibleHint": "Show or hide the aura modifier when rolling"
+    },
     "rolltables": {
       "experimentation": {
         "createJournal": "Create Journal",
@@ -990,125 +1132,6 @@
         "update": "Update"
       },
       "actions": "Actions",
-      "activeEffect": {
-        "add": "Add {score} to {value}",
-        "bonuses": {
-          "penetration": "Penetration bonus"
-        },
-        "changeMode": "Change Mode",
-        "changeValue": "Effect Value",
-        "info": {
-          "noedit": "Note: Active effect creation is not possible if the Item is owned by an Actor, edit the original or make a copy in your world to edit."
-        },
-        "mode_0": "Custom",
-        "mode_1": "Multiply",
-        "mode_2": "Add",
-        "mode_3": "Downgrade",
-        "mode_4": "Upgrade",
-        "mode_5": "Override",
-        "multiply": "Multiply {type} by ",
-        "new": "New effect",
-        "section": {
-          "inactive": "Inactive effects",
-          "passive": "Passive effects",
-          "temporary": "Temporary effects"
-        },
-        "subtypes": {
-          "attackRoll": "Attack rolls",
-          "auraLevel": "Aura's level",
-          "auraRealm": "Realm of aura",
-          "buildings": "Buildings",
-          "combatRoll": "Combat rolls",
-          "consumables": "Consumables",
-          "defRoll": "Defence rolls",
-          "fatigueTotal": "Fatigue total",
-          "formMagicRoll": "Formulaic magic rolls",
-          "inhabitantPoints": "Inhabitant points",
-          "initRoll": "Initiative rolls",
-          "inventSpell": "Invent spell",
-          "labText": "Laboratory texts",
-          "laboratories": "Laboratories",
-          "laborers": "Laborers",
-          "labs": "Laboratories",
-          "learnSpell": "Learn spell",
-          "library": "Library",
-          "magicItems": "MagicItems",
-          "magicRoll": "Magic rolls",
-          "money": "Money",
-          "none": "None",
-          "provisions": "Provisions",
-          "ritualFatigueCancelled": "Ritual fatigue levels cancelled",
-          "servants": "Servants",
-          "specialists": "Specialists",
-          "spellFatigueThreshold": "Spell fatigue threshold",
-          "spontDivider": "Spont. magic divider",
-          "spontDividerNoFatigue": "Spont. magic divider no fatigue",
-          "spontMagicRoll": "Spontaneous magic rolls",
-          "teamsters": "Teamsters",
-          "turbula": "Turbula",
-          "vis": "Vis",
-          "wages": "Wages",
-          "weapons": "Weapons & Armor",
-          "woundsTotal": "Wounds total",
-          "writingMaterials": "Writting materials",
-          "xpcoeff": "Xp multiplier",
-          "xpmod": "Xp bonus"
-        },
-        "type": {
-          "covenantBuildPoint": "Covenant's build points",
-          "covenantInhabitants": "Covenant's inhabitants",
-          "spellcasting": "Spellcasting",
-          "yearlyExpenses": "Covenant's expenses",
-          "yearlySavings": {
-            "magic": "Covenant's savings with magic",
-            "mundane": "Covenant's savings mundane"
-          }
-        },
-        "types": {
-          "AlternateArtBonus": "Bonus alternate Arts",
-          "academicAbilitiesAffinity": "Affinity Academic abilities (xp)",
-          "academicAbilitiesBonus": "Bonus Academic abilities",
-          "academicAbilitiesXPBonus": "Bonus to Academic abilities XP",
-          "affinityAlternateArt": "Affinity alternate arts (xp)",
-          "arcaneAbilitiesAffinity": "Affinity Arcane abilities (xp)",
-          "arcaneAbilitiesBonus": "Bonus Arcane abilities",
-          "arcaneAbilitiesXPBonus": "Bonus to Arcane abilities XP",
-          "arts": {
-            "affinity": "Art affinity",
-            "deficiency": "Art deficiency"
-          },
-          "characteristicBoost": "Characteristic's boost",
-          "characteristics": "Characteristics",
-          "fatigue": "Fatigue",
-          "formResistance": "Natural resistance",
-          "generalAbilitiesAffinity": "Affinity General abilities (xp)",
-          "generalAbilitiesBonus": "Bonus General abilities",
-          "generalAbilitiesXPBonus": "Bonus to General abilities XP",
-          "labActivity": "Character laboratory activity",
-          "laboratoryAttr": "Laboratory's attributes",
-          "laboratorySpec": "Laboratory's specialty",
-          "martialAbilitiesAffinity": "Affinity Martial abilities (xp)",
-          "martialAbilitiesBonus": "Bonus Martial abilities",
-          "martialAbilitiesXPBonus": "Bonus to Martial abilities XP",
-          "mysteryAbilitiesAffinity": "Affinity Mysteries abilities (xp)",
-          "mysteryAbilitiesBonus": "Bonus Mysteries abilities",
-          "mysteryAbilitiesXPBonus": "Bonus to Mystery abilities XP",
-          "nullEffect": "Null effect",
-          "optional": "Optional bonus",
-          "qualityAbilityBoost": "Quality - Ability boost",
-          "realmAlignment": "Realm alignment",
-          "realmSusceptibility": "Realm susceptibility",
-          "roll": {
-            "optional": "Optional roll bonus"
-          },
-          "spellmastery": "Spell mastery",
-          "supernaturalAbilitiesAffinity": "Affinity Supernat. abil. (xp)",
-          "supernaturalAbilitiesBonus": "Bonus Supernat. abilities",
-          "supernaturalAbilitiesXPBonus": "Bonus to Supernat. abilities XP",
-          "vitals": "Vitals",
-          "wounds": "Wounds"
-        }
-      },
       "actuals": "Current",
       "advanced": "Advanced",
       "advantage": "Advantage",
@@ -1196,7 +1219,6 @@
       "constructionPoints": "Build Points",
       "consumables": "Consumables",
       "consumablesSumary": "2 pounds per 10 pts Inhabitants (20% per craft)",
-      "contestOfMagic": "Contest of magic",
       "cord": "Cords",
       "cost": "Cost",
       "costSavings": "Cost Savings",
@@ -1491,20 +1513,6 @@
       "quickness": "Quickness",
       "range": "Range",
       "rawVis": "Raw Vis",
-      "realm": {
-        "divine": "Divine",
-        "faeric": "Faerie",
-        "infernal": "Infernal",
-        "label": "Realm",
-        "magic": "Magical",
-        "mundane": "Mundane",
-        "nightModifier": "Night Modifier",
-        "susceptible": {
-          "impact": "Due to susceptibility to {realm}, divided by {divisor}"
-        },
-        "visible": "Visible",
-        "visibleHint": "Show or hide the aura modifier when rolling"
-      },
       "refinement": "Refinement",
       "religion": "Religion",
       "reputation": "Reputation",
@@ -1662,7 +1670,6 @@
       "totalExpenditure": "Total Expenditure",
       "totalHabitants": "Total Inhabitants",
       "totalIncome": "Total Income",
-      "totalMagicResistance": "Magic resistance total",
       "totalPenetration": "Penetration total",
       "trainingRequired": "Training Required",
       "tribunal": "Tribunal",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1624,6 +1624,9 @@
       "state": {
         "label": "State"
       },
+      "states": {
+        "confidencePrompt": "Confidence prompt pending"
+      },
       "story": "Story",
       "str": "Str",
       "strength": "Strength",

--- a/lang/es.json
+++ b/lang/es.json
@@ -48,6 +48,68 @@
     "TypeWeapon": "Arma"
   },
   "arm5e": {
+    "activeEffect": {
+      "add": "Añadir",
+      "bonuses": {
+        "penetration": "Bono a Penetración"
+      },
+      "changeMode": "Cambiar de modo",
+      "changeValue": "Valor de efecto",
+      "info": {
+        "noedit": "Nota: la creación de efectos activos no es posible si el objeto está en posesión de un actor. Edita el original o haz una copia en tu mundo para editarlo."
+      },
+      "mode_0": "Personalizar",
+      "mode_1": "Multiplicar",
+      "mode_2": "Añadir",
+      "mode_3": "Reducir",
+      "mode_4": "Mejorar",
+      "mode_5": "Sobreescribir",
+      "multiply": "Multiplicar {type} por",
+      "subtypes": {
+        "auraLevel": "Nivel del aura",
+        "auraRealm": "Reino del aura",
+        "fatigueTotal": "Total por fatiga",
+        "inventSpell": "Inventar hechizo",
+        "learnSpell": "Aprender hechizos",
+        "none": "Ninguno",
+        "spontDivider": "Magia espontánea con división",
+        "spontDividerNoFatigue": "Magia espontánea sin fatiga",
+        "woundsTotal": "Total por heridas"
+      },
+      "type": {
+        "spellcasting": "Lanzamiento de hechizos"
+      },
+      "types": {
+        "academicAbilitiesAffinity": "Afinidad con Habilidades Académicas (px)",
+        "academicAbilitiesBonus": "Bono a Habilidades Académicas",
+        "arcaneAbilitiesAffinity": "Afinidad con Habilidades Arcanas (px)",
+        "arcaneAbilitiesBonus": "Bono a Habilidades Arcanas",
+        "arts": {
+          "affinity": "Afinidad con Arte",
+          "deficiency": "Deficiencia en Arte"
+        },
+        "characteristics": "Características",
+        "fatigue": "Fatiga",
+        "formResistance": "Resistencia natural",
+        "generalAbilitiesAffinity": "Afinidad con Habilidades Generales (px)",
+        "generalAbilitiesBonus": "Bono a Habilidades Generales",
+        "labActivity": "Actividad de laboratorio",
+        "laboratoryAttr": "Atributos del laboratorio",
+        "laboratorySpec": "Especialización del laboratorio",
+        "martialAbilitiesAffinity": "Afinidad con Habilidades Marciales  (px)",
+        "martialAbilitiesBonus": "Bono a Habilidades Marciales",
+        "mysteryAbilitiesAffinity": "Afinidad con Habilidades Mistéricas (px)",
+        "mysteryAbilitiesBonus": "Bono a Habilidades Mistéricas",
+        "nullEffect": "Sin efecto",
+        "optional": "Bono opcional",
+        "realmAlignment": "Alineamiento con Reino",
+        "supernaturalAbilitiesAffinity": "Afinidad con Habilidades Sobrenaturales (px)",
+        "supernaturalAbilitiesBonus": "Bono a Habilidades Sobrenaturales",
+        "supernaturalAbilitiesXPBonus": "Bono en PX a habilidades sobrenaturales",
+        "vitals": "Vitales",
+        "wounds": "Heridas"
+      }
+    },
     "activity": {
       "activity": "Actividad",
       "adventuring": "Aventuras",
@@ -210,6 +272,10 @@
         "clearAura": "Anular aura",
         "setAura": "Configurar aura"
       }
+    },
+    "chat": {
+      "contestOfMagic": "Enfrentamiento mágico",
+      "totalMagicResistance": "Total de resistencia mágica"
     },
     "config": {
       "sourcebookFilter": "Filtro por manuales",
@@ -486,6 +552,14 @@
         "name": "Habilidades"
       }
     },
+    "realm": {
+      "divine": "Divino",
+      "faeric": "Feérico",
+      "infernal": "Infernal",
+      "label": "Reino",
+      "magic": "Mágico",
+      "mundane": "Mundano"
+    },
     "sanatorium": {
       "button": {
         "endSeason": "Fin de la estación",
@@ -560,68 +634,6 @@
         "rollback": "Retroceder",
         "update": "Actualizar"
       },
-      "activeEffect": {
-        "add": "Añadir",
-        "bonuses": {
-          "penetration": "Bono a Penetración"
-        },
-        "changeMode": "Cambiar de modo",
-        "changeValue": "Valor de efecto",
-        "info": {
-          "noedit": "Nota: la creación de efectos activos no es posible si el objeto está en posesión de un actor. Edita el original o haz una copia en tu mundo para editarlo."
-        },
-        "mode_0": "Personalizar",
-        "mode_1": "Multiplicar",
-        "mode_2": "Añadir",
-        "mode_3": "Reducir",
-        "mode_4": "Mejorar",
-        "mode_5": "Sobreescribir",
-        "multiply": "Multiplicar {type} por",
-        "subtypes": {
-          "auraLevel": "Nivel del aura",
-          "auraRealm": "Reino del aura",
-          "fatigueTotal": "Total por fatiga",
-          "inventSpell": "Inventar hechizo",
-          "learnSpell": "Aprender hechizos",
-          "none": "Ninguno",
-          "spontDivider": "Magia espontánea con división",
-          "spontDividerNoFatigue": "Magia espontánea sin fatiga",
-          "woundsTotal": "Total por heridas"
-        },
-        "type": {
-          "spellcasting": "Lanzamiento de hechizos"
-        },
-        "types": {
-          "academicAbilitiesAffinity": "Afinidad con Habilidades Académicas (px)",
-          "academicAbilitiesBonus": "Bono a Habilidades Académicas",
-          "arcaneAbilitiesAffinity": "Afinidad con Habilidades Arcanas (px)",
-          "arcaneAbilitiesBonus": "Bono a Habilidades Arcanas",
-          "arts": {
-            "affinity": "Afinidad con Arte",
-            "deficiency": "Deficiencia en Arte"
-          },
-          "characteristics": "Características",
-          "fatigue": "Fatiga",
-          "formResistance": "Resistencia natural",
-          "generalAbilitiesAffinity": "Afinidad con Habilidades Generales (px)",
-          "generalAbilitiesBonus": "Bono a Habilidades Generales",
-          "labActivity": "Actividad de laboratorio",
-          "laboratoryAttr": "Atributos del laboratorio",
-          "laboratorySpec": "Especialización del laboratorio",
-          "martialAbilitiesAffinity": "Afinidad con Habilidades Marciales  (px)",
-          "martialAbilitiesBonus": "Bono a Habilidades Marciales",
-          "mysteryAbilitiesAffinity": "Afinidad con Habilidades Mistéricas (px)",
-          "mysteryAbilitiesBonus": "Bono a Habilidades Mistéricas",
-          "nullEffect": "Sin efecto",
-          "optional": "Bono opcional",
-          "realmAlignment": "Alineamiento con Reino",
-          "supernaturalAbilitiesAffinity": "Afinidad con Habilidades Sobrenaturales (px)",
-          "supernaturalAbilitiesBonus": "Bono a Habilidades Sobrenaturales",
-          "supernaturalAbilitiesXPBonus": "Bono en PX a habilidades sobrenaturales",
-          "vitals": "Vitales",
-          "wounds": "Heridas"
-        }
-      },
       "actuals": "Actual",
       "advanced": "Avanzado",
       "advantage": "Ventaja",
@@ -695,7 +707,6 @@
       "constructionPoints": "Puntos de Construcción",
       "consumables": "Consumibles",
       "consumablesSumary": "2 libras por 10 puntos de Habitantes (20% por manufactura)",
-      "contestOfMagic": "Enfrentamiento mágico",
       "cord": "Ligaduras",
       "cost": "Coste",
       "costSavings": "Ahorro de Costes",
@@ -956,14 +967,6 @@
       "quickness": "Rapidez",
       "range": "Alcance",
       "rawVis": "Vis en bruto",
-      "realm": {
-        "divine": "Divino",
-        "faeric": "Feérico",
-        "infernal": "Infernal",
-        "label": "Reino",
-        "magic": "Mágico",
-        "mundane": "Mundano"
-      },
       "refinement": "Perfeccionamiento",
       "religion": "Religión",
       "reputation": "Reputación",
@@ -1088,7 +1091,6 @@
       "totalExpenditure": "Gasto Final",
       "totalHabitants": "Habitantes totales",
       "totalIncome": "Ingresos Totales",
-      "totalMagicResistance": "Total de resistencia mágica",
       "totalPenetration": "Total de penetración",
       "trainingRequired": "Se necesita formación",
       "tribunal": "Tribunal",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -54,6 +54,125 @@
     }
   },
   "arm5e": {
+    "activeEffect": {
+      "add": "Ajouter {score} à {value}",
+      "bonuses": {
+        "penetration": "Bonus de Pénétration"
+      },
+      "changeMode": "Mode",
+      "changeValue": "Valeur de l'Effet",
+      "info": {
+        "noedit": "Remarque : la création d'un effet actif n'est pas possible si l'élément appartient à un acteur, modifiez l'original ou faites une copie dans votre monde pour le modifier."
+      },
+      "mode_0": "Personnalisé",
+      "mode_1": "Multiplier",
+      "mode_2": "Ajouter",
+      "mode_3": "Rétrograder",
+      "mode_4": "Améliorer",
+      "mode_5": "Remplacer",
+      "multiply": "Multiplier {type} par ",
+      "new": "Nouvel effet",
+      "section": {
+        "inactive": "Effets inactifs",
+        "passive": "Effets passifs",
+        "temporary": "Effets temporaires"
+      },
+      "subtypes": {
+        "attackRoll": "Jets d'attaque",
+        "auraLevel": "Niveau de l'aura",
+        "auraRealm": "Domaine de l'aura",
+        "buildings": "Bâtiments",
+        "combatRoll": "Jets de combat",
+        "consumables": "Fournitures",
+        "defRoll": "Jet de défense",
+        "fatigueTotal": "Total de Fatigue",
+        "formMagicRoll": "Jets de magie formulaïque",
+        "inhabitantPoints": "Inhabitant points",
+        "initRoll": "Jets d'initiative",
+        "inventSpell": "Invention de sort",
+        "labText": "Textes de laboratoire",
+        "laboratories": "Laboratoires",
+        "laborers": "Paysans",
+        "labs": "Laboratoires",
+        "learnSpell": "Apprentissage de sort",
+        "library": "Bibliothèque",
+        "magicItems": "Objets magiques",
+        "magicRoll": "Jets de magie",
+        "money": "Argent",
+        "none": "Aucun",
+        "provisions": "Provisions",
+        "ritualFatigueCancelled": "Niveaux de Fatigue rituelle annulés",
+        "servants": "Serviteurs",
+        "specialists": "Spécialistes",
+        "spellFatigueThreshold": "Seuil de Fatigue des sorts",
+        "spontDivider": "Diviseur de magie spontanée",
+        "spontDividerNoFatigue": "Diviseur de magie spontanée sans fatigue",
+        "spontMagicRoll": "Jets de magie spontanée",
+        "teamsters": "Manouvriers",
+        "turbula": "Turbula",
+        "vis": "Vis",
+        "wages": "Gages",
+        "weapons": "Armes & Armures",
+        "woundsTotal": "Total de Blessures",
+        "writingMaterials": "Matériel d'écriture",
+        "xpcoeff": "Multiplicateur d'XP",
+        "xpmod": "Bonus d'Xp"
+      },
+      "type": {
+        "covenantBuildPoint": "Points de construction de l'alliance",
+        "covenantInhabitants": "Les habitants de l'Alliance",
+        "spellcasting": "Lancement de Sorts",
+        "yearlyExpenses": "Dépenses de l'alliance",
+        "yearlySavings": {
+          "magic": "Economies de l'Alliance dûes à la magie",
+          "mundane": "Economies de l'alliance vulgaire"
+        }
+      },
+      "types": {
+        "AlternateArtBonus": "Bonus d'Arts alternatifs",
+        "academicAbilitiesAffinity": "Affinité Compétences Académiques (xp)",
+        "academicAbilitiesBonus": "Bonus aux Compétences Académiques",
+        "academicAbilitiesXPBonus": "Bonus d'XP aux compétences Académiques",
+        "affinityAlternateArt": "Affinité pour les arts alternatifs (xp)",
+        "arcaneAbilitiesAffinity": "Affinité Compétences Mystiques (xp)",
+        "arcaneAbilitiesBonus": "Bonus aux Compétences Mystiques",
+        "arcaneAbilitiesXPBonus": "Bonus d'XP aux compétences Arcanique",
+        "arts": {
+          "affinity": "Affinité pour un Art",
+          "deficiency": "Art déficient"
+        },
+        "characteristicBoost": "Augmentation de Caractéristique",
+        "characteristics": "Caractéristiques",
+        "fatigue": "Fatigue",
+        "formResistance": "Résistance naturelle",
+        "generalAbilitiesAffinity": "Affinité Compétences Générales (xp)",
+        "generalAbilitiesBonus": "Bonus aux Compétences Générales",
+        "generalAbilitiesXPBonus": "Bonus d'XP aux compétences Générales",
+        "labActivity": "Activité de laboratoire du personnage",
+        "laboratoryAttr": "Attributs de Laboratoires",
+        "laboratorySpec": "Spécialité de laboratoire",
+        "martialAbilitiesAffinity": "Affinité Compétences Martiales (xp)",
+        "martialAbilitiesBonus": "Bonus aux Compétences Martiales",
+        "martialAbilitiesXPBonus": "Bonus d'XP aux compétences Martiales",
+        "mysteryAbilitiesAffinity": "Affinité Compétences des Mystères (xp)",
+        "mysteryAbilitiesBonus": "Bonus aux Compétences des Mystères",
+        "mysteryAbilitiesXPBonus": "Bonus d'XP aux compétences des Mystères",
+        "nullEffect": "Aucun Effet",
+        "optional": "Bonus Optionnel",
+        "qualityAbilityBoost": "Qualité – Augmentation de Compétence",
+        "realmAlignment": "Alignement avec la Dimension",
+        "realmSusceptibility": "Vulnérabilité à la Dimension",
+        "roll": {
+          "optional": "Bonus optionnel au jet de dé"
+        },
+        "spellmastery": "Maitrise de sort",
+        "supernaturalAbilitiesAffinity": "Affinité Compétences Surnaturelles (xp)",
+        "supernaturalAbilitiesBonus": "Bonus aux Compétences Surnaturelles",
+        "supernaturalAbilitiesXPBonus": "Bonus d'XP aux compétences Supernaturelles",
+        "vitals": "Vitaux",
+        "wounds": "Blessure"
+      }
+    },
     "activity": {
       "activity": "Activité",
       "adventuring": "Aventure",
@@ -252,6 +371,10 @@
         "clearAura": "Réinitialisé l'Aura",
         "setAura": "Configure l'Aura"
       }
+    },
+    "chat": {
+      "contestOfMagic": "Concours de Magie",
+      "totalMagicResistance": "Total de Résistance Magique"
     },
     "combat": {
       "damage": {
@@ -713,6 +836,20 @@
         "name": "Compétences"
       }
     },
+    "realm": {
+      "divine": "Divin",
+      "faeric": "Féérique",
+      "infernal": "Infernal",
+      "label": "Dimension",
+      "magic": "Magique",
+      "mundane": "Vulgaire",
+      "nightModifier": "Modificateur nocturne",
+      "susceptible": {
+        "impact": "En raison d’une vulnérabilité au {realm}, divisée par {divisor}"
+      },
+      "visible": "Visible",
+      "visibleHint": "Afficher ou masquer le modificateur d'aura lors du lancer"
+    },
     "rolltables": {
       "experimentation": {
         "createJournal": "Créer un journal",
@@ -990,125 +1127,6 @@
         "update": "Mise à jours"
       },
       "actions": "Actions",
-      "activeEffect": {
-        "add": "Ajouter {score} à {value}",
-        "bonuses": {
-          "penetration": "Bonus de Pénétration"
-        },
-        "changeMode": "Mode",
-        "changeValue": "Valeur de l'Effet",
-        "info": {
-          "noedit": "Remarque : la création d'un effet actif n'est pas possible si l'élément appartient à un acteur, modifiez l'original ou faites une copie dans votre monde pour le modifier."
-        },
-        "mode_0": "Personnalisé",
-        "mode_1": "Multiplier",
-        "mode_2": "Ajouter",
-        "mode_3": "Rétrograder",
-        "mode_4": "Améliorer",
-        "mode_5": "Remplacer",
-        "multiply": "Multiplier {type} par ",
-        "new": "Nouvel effet",
-        "section": {
-          "inactive": "Effets inactifs",
-          "passive": "Effets passifs",
-          "temporary": "Effets temporaires"
-        },
-        "subtypes": {
-          "attackRoll": "Jets d'attaque",
-          "auraLevel": "Niveau de l'aura",
-          "auraRealm": "Domaine de l'aura",
-          "buildings": "Bâtiments",
-          "combatRoll": "Jets de combat",
-          "consumables": "Fournitures",
-          "defRoll": "Jet de défense",
-          "fatigueTotal": "Total de Fatigue",
-          "formMagicRoll": "Jets de magie formulaïque",
-          "inhabitantPoints": "Inhabitant points",
-          "initRoll": "Jets d'initiative",
-          "inventSpell": "Invention de sort",
-          "labText": "Textes de laboratoire",
-          "laboratories": "Laboratoires",
-          "laborers": "Paysans",
-          "labs": "Laboratoires",
-          "learnSpell": "Apprentissage de sort",
-          "library": "Bibliothèque",
-          "magicItems": "Objets magiques",
-          "magicRoll": "Jets de magie",
-          "money": "Argent",
-          "none": "Aucun",
-          "provisions": "Provisions",
-          "ritualFatigueCancelled": "Niveaux de Fatigue rituelle annulés",
-          "servants": "Serviteurs",
-          "specialists": "Spécialistes",
-          "spellFatigueThreshold": "Seuil de Fatigue des sorts",
-          "spontDivider": "Diviseur de magie spontanée",
-          "spontDividerNoFatigue": "Diviseur de magie spontanée sans fatigue",
-          "spontMagicRoll": "Jets de magie spontanée",
-          "teamsters": "Manouvriers",
-          "turbula": "Turbula",
-          "vis": "Vis",
-          "wages": "Gages",
-          "weapons": "Armes & Armures",
-          "woundsTotal": "Total de Blessures",
-          "writingMaterials": "Matériel d'écriture",
-          "xpcoeff": "Multiplicateur d'XP",
-          "xpmod": "Bonus d'Xp"
-        },
-        "type": {
-          "covenantBuildPoint": "Points de construction de l'alliance",
-          "covenantInhabitants": "Les habitants de l'Alliance",
-          "spellcasting": "Lancement de Sorts",
-          "yearlyExpenses": "Dépenses de l'alliance",
-          "yearlySavings": {
-            "magic": "Economies de l'Alliance dûes à la magie",
-            "mundane": "Economies de l'alliance vulgaire"
-          }
-        },
-        "types": {
-          "AlternateArtBonus": "Bonus d'Arts alternatifs",
-          "academicAbilitiesAffinity": "Affinité Compétences Académiques (xp)",
-          "academicAbilitiesBonus": "Bonus aux Compétences Académiques",
-          "academicAbilitiesXPBonus": "Bonus d'XP aux compétences Académiques",
-          "affinityAlternateArt": "Affinité pour les arts alternatifs (xp)",
-          "arcaneAbilitiesAffinity": "Affinité Compétences Mystiques (xp)",
-          "arcaneAbilitiesBonus": "Bonus aux Compétences Mystiques",
-          "arcaneAbilitiesXPBonus": "Bonus d'XP aux compétences Arcanique",
-          "arts": {
-            "affinity": "Affinité pour un Art",
-            "deficiency": "Art déficient"
-          },
-          "characteristicBoost": "Augmentation de Caractéristique",
-          "characteristics": "Caractéristiques",
-          "fatigue": "Fatigue",
-          "formResistance": "Résistance naturelle",
-          "generalAbilitiesAffinity": "Affinité Compétences Générales (xp)",
-          "generalAbilitiesBonus": "Bonus aux Compétences Générales",
-          "generalAbilitiesXPBonus": "Bonus d'XP aux compétences Générales",
-          "labActivity": "Activité de laboratoire du personnage",
-          "laboratoryAttr": "Attributs de Laboratoires",
-          "laboratorySpec": "Spécialité de laboratoire",
-          "martialAbilitiesAffinity": "Affinité Compétences Martiales (xp)",
-          "martialAbilitiesBonus": "Bonus aux Compétences Martiales",
-          "martialAbilitiesXPBonus": "Bonus d'XP aux compétences Martiales",
-          "mysteryAbilitiesAffinity": "Affinité Compétences des Mystères (xp)",
-          "mysteryAbilitiesBonus": "Bonus aux Compétences des Mystères",
-          "mysteryAbilitiesXPBonus": "Bonus d'XP aux compétences des Mystères",
-          "nullEffect": "Aucun Effet",
-          "optional": "Bonus Optionnel",
-          "qualityAbilityBoost": "Qualité – Augmentation de Compétence",
-          "realmAlignment": "Alignement avec la Dimension",
-          "realmSusceptibility": "Vulnérabilité à la Dimension",
-          "roll": {
-            "optional": "Bonus optionnel au jet de dé"
-          },
-          "spellmastery": "Maitrise de sort",
-          "supernaturalAbilitiesAffinity": "Affinité Compétences Surnaturelles (xp)",
-          "supernaturalAbilitiesBonus": "Bonus aux Compétences Surnaturelles",
-          "supernaturalAbilitiesXPBonus": "Bonus d'XP aux compétences Supernaturelles",
-          "vitals": "Vitaux",
-          "wounds": "Blessure"
-        }
-      },
       "actuals": "Actuel",
       "advanced": "Avancé",
       "advantage": "Avantage",
@@ -1196,7 +1214,6 @@
       "constructionPoints": "Points de construction",
       "consumables": "Consommables",
       "consumablesSumary": "2 livres pour 10 pts d'Habitants (20% par artisanat)",
-      "contestOfMagic": "Concours de Magie",
       "cord": "Cordes",
       "cost": "Coût",
       "costSavings": "Réduction de coût",
@@ -1491,20 +1508,6 @@
       "quickness": "Vivacitée",
       "range": "Portée",
       "rawVis": "Vis Brute",
-      "realm": {
-        "divine": "Divin",
-        "faeric": "Féérique",
-        "infernal": "Infernal",
-        "label": "Dimension",
-        "magic": "Magique",
-        "mundane": "Vulgaire",
-        "nightModifier": "Modificateur nocturne",
-        "susceptible": {
-          "impact": "En raison d’une vulnérabilité au {realm}, divisée par {divisor}"
-        },
-        "visible": "Visible",
-        "visibleHint": "Afficher ou masquer le modificateur d'aura lors du lancer"
-      },
       "refinement": "Raffinement",
       "religion": "Religion",
       "reputation": "Réputation",
@@ -1659,7 +1662,6 @@
       "totalExpenditure": "Dépense totale",
       "totalHabitants": "Total d'habitants",
       "totalIncome": "Revenus totaux",
-      "totalMagicResistance": "Total de Résistance Magique",
       "totalPenetration": "Total de Pénétration",
       "trainingRequired": "Entrainement Requis",
       "tribunal": "Tribunal",

--- a/lang/it.json
+++ b/lang/it.json
@@ -48,6 +48,68 @@
     "TypeWeapon": "Arma"
   },
   "arm5e": {
+    "activeEffect": {
+      "add": "Aggiungere ",
+      "bonuses": {
+        "penetration": "Bonus penetrazione"
+      },
+      "changeMode": "Cambiare modalità",
+      "changeValue": "Valore Effetto",
+      "info": {
+        "noedit": "Nota: la crezione di effetti attivi non è possibile quando un oggetto è posseduto da un attore. Modifica l'originale o creane una copia damodificare nel mondo."
+      },
+      "mode_0": "Personalizzata",
+      "mode_1": "Moltiplicare",
+      "mode_2": "Aggiungere",
+      "mode_3": "Ridurre",
+      "mode_4": "Potenziare",
+      "mode_5": "Bypassare",
+      "multiply": "Moltiplicare {type} per ",
+      "subtypes": {
+        "auraLevel": "Livello Aura",
+        "auraRealm": "Reame di aura",
+        "fatigueTotal": "Totale fatica",
+        "inventSpell": "Inventa incantesimo",
+        "learnSpell": "Impara incantesimo",
+        "none": "Nessuno",
+        "spontDivider": "Divisore magia spontanea",
+        "spontDividerNoFatigue": "Divisore magia spontanea senza fatica",
+        "woundsTotal": "Totale ferite"
+      },
+      "type": {
+        "spellcasting": "Lanciare incantesimi"
+      },
+      "types": {
+        "academicAbilitiesAffinity": "Affinità abilità Academiche (pe)",
+        "academicAbilitiesBonus": "Bonus abilità Academiche ",
+        "arcaneAbilitiesAffinity": "Affinità abilità Arcane (pe)",
+        "arcaneAbilitiesBonus": "Bonus abilità Arcane",
+        "arts": {
+          "affinity": "Affinità per Arte",
+          "deficiency": "Deficienza in Arte"
+        },
+        "characteristics": "Caratteristiche",
+        "fatigue": "Fatica",
+        "formResistance": "Resistenza Naturale",
+        "generalAbilitiesAffinity": "Affinità abilità Generali (pe)",
+        "generalAbilitiesBonus": "Bonus abilità Generali",
+        "labActivity": "Attività Laboratorio",
+        "laboratoryAttr": "Attributi Laboratorio",
+        "laboratorySpec": "Specialità Laboratorio",
+        "martialAbilitiesAffinity": "Affinità abilità Marziali (pe)",
+        "martialAbilitiesBonus": "Bonus abilità Marziali",
+        "mysteryAbilitiesAffinity": "Affinità abilità Mysteriche (pe)",
+        "mysteryAbilitiesBonus": "Bonus abilità Mysteriche",
+        "nullEffect": "Effetto nullo",
+        "optional": "Bonus opzionale",
+        "realmAlignment": "Allineamento Reame",
+        "supernaturalAbilitiesAffinity": "Affinità abilità Supernat. (pe)",
+        "supernaturalAbilitiesBonus": "Bonus abilità Supernat.",
+        "supernaturalAbilitiesXPBonus": "Bonus ad abilità Supernat. PE",
+        "vitals": "Segni vitali",
+        "wounds": "Ferite"
+      }
+    },
     "activity": {
       "activity": "Attività",
       "adventuring": "Avventurarsi",
@@ -211,6 +273,10 @@
         "clearAura": "Rimuovi Aura",
         "setAura": "Configura Aura"
       }
+    },
+    "chat": {
+      "contestOfMagic": "Contesa di magia",
+      "totalMagicResistance": "Totale resistenza magica"
     },
     "config": {
       "sourcebookFilter": "Filtro libro fonte"
@@ -489,6 +555,14 @@
         "name": "Abilità"
       }
     },
+    "realm": {
+      "divine": "Divino",
+      "faeric": "Fatato",
+      "infernal": "Infernale",
+      "label": "Reame",
+      "magic": "Magico",
+      "mundane": "Mondano"
+    },
     "sanatorium": {
       "labHealth": "Aiuto del Sanctum",
       "magicalHelp": "Aiuto magico",
@@ -540,68 +614,6 @@
         "rest": "Riposare",
         "rollback": "Ripristinare",
         "update": "Aggiornare"
-      },
-      "activeEffect": {
-        "add": "Aggiungere ",
-        "bonuses": {
-          "penetration": "Bonus penetrazione"
-        },
-        "changeMode": "Cambiare modalità",
-        "changeValue": "Valore Effetto",
-        "info": {
-          "noedit": "Nota: la crezione di effetti attivi non è possibile quando un oggetto è posseduto da un attore. Modifica l'originale o creane una copia damodificare nel mondo."
-        },
-        "mode_0": "Personalizzata",
-        "mode_1": "Moltiplicare",
-        "mode_2": "Aggiungere",
-        "mode_3": "Ridurre",
-        "mode_4": "Potenziare",
-        "mode_5": "Bypassare",
-        "multiply": "Moltiplicare {type} per ",
-        "subtypes": {
-          "auraLevel": "Livello Aura",
-          "auraRealm": "Reame di aura",
-          "fatigueTotal": "Totale fatica",
-          "inventSpell": "Inventa incantesimo",
-          "learnSpell": "Impara incantesimo",
-          "none": "Nessuno",
-          "spontDivider": "Divisore magia spontanea",
-          "spontDividerNoFatigue": "Divisore magia spontanea senza fatica",
-          "woundsTotal": "Totale ferite"
-        },
-        "type": {
-          "spellcasting": "Lanciare incantesimi"
-        },
-        "types": {
-          "academicAbilitiesAffinity": "Affinità abilità Academiche (pe)",
-          "academicAbilitiesBonus": "Bonus abilità Academiche ",
-          "arcaneAbilitiesAffinity": "Affinità abilità Arcane (pe)",
-          "arcaneAbilitiesBonus": "Bonus abilità Arcane",
-          "arts": {
-            "affinity": "Affinità per Arte",
-            "deficiency": "Deficienza in Arte"
-          },
-          "characteristics": "Caratteristiche",
-          "fatigue": "Fatica",
-          "formResistance": "Resistenza Naturale",
-          "generalAbilitiesAffinity": "Affinità abilità Generali (pe)",
-          "generalAbilitiesBonus": "Bonus abilità Generali",
-          "labActivity": "Attività Laboratorio",
-          "laboratoryAttr": "Attributi Laboratorio",
-          "laboratorySpec": "Specialità Laboratorio",
-          "martialAbilitiesAffinity": "Affinità abilità Marziali (pe)",
-          "martialAbilitiesBonus": "Bonus abilità Marziali",
-          "mysteryAbilitiesAffinity": "Affinità abilità Mysteriche (pe)",
-          "mysteryAbilitiesBonus": "Bonus abilità Mysteriche",
-          "nullEffect": "Effetto nullo",
-          "optional": "Bonus opzionale",
-          "realmAlignment": "Allineamento Reame",
-          "supernaturalAbilitiesAffinity": "Affinità abilità Supernat. (pe)",
-          "supernaturalAbilitiesBonus": "Bonus abilità Supernat.",
-          "supernaturalAbilitiesXPBonus": "Bonus ad abilità Supernat. PE",
-          "vitals": "Segni vitali",
-          "wounds": "Ferite"
-        }
       },
       "actuals": "Attuale",
       "advanced": "Avanzato",
@@ -676,7 +688,6 @@
       "constructionPoints": "Punti Costruzione",
       "consumables": "Consumabili",
       "consumablesSumary": "2 soldi per 10 pt Abitanti (20% per maestranza)",
-      "contestOfMagic": "Contesa di magia",
       "cord": "Corde",
       "cost": "Costo",
       "costSavings": "Risparmi sulle Spese",
@@ -940,14 +951,6 @@
       "quickness": "Rapidità",
       "range": "Gittata",
       "rawVis": "Vis grezzo",
-      "realm": {
-        "divine": "Divino",
-        "faeric": "Fatato",
-        "infernal": "Infernale",
-        "label": "Reame",
-        "magic": "Magico",
-        "mundane": "Mondano"
-      },
       "refinement": "Perfezionamento",
       "religion": "Religione",
       "reputation": "Reputazione",
@@ -1077,7 +1080,6 @@
       "totalExpenditure": "Spese Totali",
       "totalHabitants": "Totale Abitanti",
       "totalIncome": "Ricavi Totali",
-      "totalMagicResistance": "Totale resistenza magica",
       "totalPenetration": "Totale penetrazione",
       "trainingRequired": "Allenamento necessario",
       "tribunal": "Tribunale",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -101,6 +101,115 @@
     }
   },
   "arm5e": {
+    "activeEffect": {
+      "add": "Adicionar {score} a(o) {value}",
+      "bonuses": {
+        "penetration": "Bônus de penetração"
+      },
+      "changeMode": "Mudar Modo",
+      "changeValue": "Valor do efeito",
+      "info": {
+        "noedit": "Nota: Criação de efeito ativo é impossível se o item é possuído por um Ator, edite o efeito original e faça uma cópia no seu mundo para editar."
+      },
+      "mode_0": "Customizado",
+      "mode_1": "Multiplicar",
+      "mode_2": "Adicionar",
+      "mode_3": "Involuir",
+      "mode_4": "Evoluir",
+      "mode_5": "Sobrescrever",
+      "multiply": "Multiplicar {type} por ",
+      "new": "Novo efeito",
+      "section": {
+        "inactive": "Efeitos inativos",
+        "passive": "Efeitos passivos",
+        "temporary": "Efeitos temporários"
+      },
+      "subtypes": {
+        "attackRoll": "Rolagens de ataque",
+        "auraLevel": "Nível da aura",
+        "auraRealm": "Reino da aura",
+        "buildings": "Construções",
+        "combatRoll": "Rolagens de combate",
+        "consumables": "Consumíveis",
+        "defRoll": "Rolagens de defesa",
+        "fatigueTotal": "Total de fadiga",
+        "formMagicRoll": "Rolagens de magia formulaica",
+        "inhabitantPoints": "Pontos de habitantes",
+        "initRoll": "Rolagens de iniciativa",
+        "inventSpell": "Inventar magia",
+        "labText": "Textos de Lab.",
+        "laboratories": "Laboratórios",
+        "laborers": "Operários",
+        "labs": "Laboratórios",
+        "learnSpell": "Aprender magia",
+        "library": "Biblioteca",
+        "magicItems": "Encantamentos",
+        "magicRoll": "Rolagens de magia",
+        "money": "Dinheiro",
+        "none": "Nenhum",
+        "provisions": "Provisões",
+        "servants": "Servos",
+        "specialists": "Especialistas",
+        "spontDivider": "Divisor de magia esp.",
+        "spontDividerNoFatigue": "Divisor de magia esp. sem fadiga",
+        "spontMagicRoll": "Rolagens de magia espontânea",
+        "teamsters": "Abastecedores",
+        "turbula": "Guardas",
+        "vis": "Vis",
+        "wages": "Salários",
+        "weapons": "Armas & Armaduras",
+        "woundsTotal": "Total de ferimentos",
+        "writingMaterials": "Materiais de escrita",
+        "xpcoeff": "Multiplicador de exp",
+        "xpmod": "Bônus de exp"
+      },
+      "type": {
+        "covenantBuildPoint": "Pontos de construção do concílio",
+        "covenantInhabitants": "Habitantes do concílio",
+        "spellcasting": "Conjuração",
+        "yearlyExpenses": "Despesas do concílio",
+        "yearlySavings": {
+          "magic": "Redução de custos mágica",
+          "mundane": "Redução de custos mundana"
+        }
+      },
+      "types": {
+        "AlternateArtBonus": "Bônus p/ Artes Alternativas",
+        "academicAbilitiesAffinity": "Afinidade c/ Hab. Acadêmicas (Exp)",
+        "academicAbilitiesBonus": "Bônus p/ Hab. Acadêmicas",
+        "affinityAlternateArt": "Afinidade c/ Artes Alternativas (Exp)",
+        "arcaneAbilitiesAffinity": "Afinidade c/ Hab. Arcanas (Exp)",
+        "arcaneAbilitiesBonus": "Bônus p/ Hab. Arcanas",
+        "arts": {
+          "affinity": "Afinidade com arte",
+          "deficiency": "Deficiência com arte"
+        },
+        "characteristics": "Características",
+        "fatigue": "Fadiga",
+        "formResistance": "Resistência natural",
+        "generalAbilitiesAffinity": "Afinidade c/ Hab. Gerais (Exp)",
+        "generalAbilitiesBonus": "Bônus p/ Hab. Gerais",
+        "labActivity": "Atividade de lab. do personagem",
+        "laboratoryAttr": "Características de Laboratório",
+        "laboratorySpec": "Especialidade de Laboratório",
+        "martialAbilitiesAffinity": "Afinidade c/ Hab. Marciais (Exp)",
+        "martialAbilitiesBonus": "Bônus p/ Hab. Marciais",
+        "mysteryAbilitiesAffinity": "Afinidade c/ Hab. de Mistério (Exp)",
+        "mysteryAbilitiesBonus": "Bônusp/ Hab. Mistério",
+        "nullEffect": "Efeito nulo",
+        "optional": "Bônus opcional",
+        "realmAlignment": "Alinhamento de Reino",
+        "roll": {
+          "optional": "Bônus de rolagem opcional"
+        },
+        "spellmastery": "Aperfeiçoamento de magia",
+        "supernaturalAbilitiesAffinity": "Afinidade c/ Hab. Sobrenaturais (Exp)",
+        "supernaturalAbilitiesBonus": "Bônus p/ Hab.Sobrenaturais",
+        "supernaturalAbilitiesXPBonus": "Bônus EXP de Hab. Sobrenaturais",
+        "vitals": "Vitas",
+        "wounds": "Ferimentos"
+      }
+    },
     "activity": {
       "activity": "Atividade",
       "adventuring": "Aventura",
@@ -279,6 +388,10 @@
         "clearAura": "Limpar Aura",
         "setAura": "Configurar Aura"
       }
+    },
+    "chat": {
+      "contestOfMagic": "Contestação de Magia",
+      "totalMagicResistance": "Total de resistência mágica"
     },
     "combat": {
       "damage": {
@@ -707,6 +820,17 @@
         "name": "Habilidades"
       }
     },
+    "realm": {
+      "divine": "Divino",
+      "faeric": "Feérico",
+      "infernal": "Infernal",
+      "label": "Reino",
+      "magic": "Mágico",
+      "mundane": "Mundano",
+      "nightModifier": "Modificador Noturno",
+      "visible": "Visível",
+      "visibleHint": "Mostrar ou esconder mod. de aura quando rolando"
+    },
     "rolltables": {
       "experimentation": ""
     },
@@ -835,115 +959,6 @@
         "rollback": "Reverter",
         "update": "Atualizar"
       },
-      "activeEffect": {
-        "add": "Adicionar {score} a(o) {value}",
-        "bonuses": {
-          "penetration": "Bônus de penetração"
-        },
-        "changeMode": "Mudar Modo",
-        "changeValue": "Valor do efeito",
-        "info": {
-          "noedit": "Nota: Criação de efeito ativo é impossível se o item é possuído por um Ator, edite o efeito original e faça uma cópia no seu mundo para editar."
-        },
-        "mode_0": "Customizado",
-        "mode_1": "Multiplicar",
-        "mode_2": "Adicionar",
-        "mode_3": "Involuir",
-        "mode_4": "Evoluir",
-        "mode_5": "Sobrescrever",
-        "multiply": "Multiplicar {type} por ",
-        "new": "Novo efeito",
-        "section": {
-          "inactive": "Efeitos inativos",
-          "passive": "Efeitos passivos",
-          "temporary": "Efeitos temporários"
-        },
-        "subtypes": {
-          "attackRoll": "Rolagens de ataque",
-          "auraLevel": "Nível da aura",
-          "auraRealm": "Reino da aura",
-          "buildings": "Construções",
-          "combatRoll": "Rolagens de combate",
-          "consumables": "Consumíveis",
-          "defRoll": "Rolagens de defesa",
-          "fatigueTotal": "Total de fadiga",
-          "formMagicRoll": "Rolagens de magia formulaica",
-          "inhabitantPoints": "Pontos de habitantes",
-          "initRoll": "Rolagens de iniciativa",
-          "inventSpell": "Inventar magia",
-          "labText": "Textos de Lab.",
-          "laboratories": "Laboratórios",
-          "laborers": "Operários",
-          "labs": "Laboratórios",
-          "learnSpell": "Aprender magia",
-          "library": "Biblioteca",
-          "magicItems": "Encantamentos",
-          "magicRoll": "Rolagens de magia",
-          "money": "Dinheiro",
-          "none": "Nenhum",
-          "provisions": "Provisões",
-          "servants": "Servos",
-          "specialists": "Especialistas",
-          "spontDivider": "Divisor de magia esp.",
-          "spontDividerNoFatigue": "Divisor de magia esp. sem fadiga",
-          "spontMagicRoll": "Rolagens de magia espontânea",
-          "teamsters": "Abastecedores",
-          "turbula": "Guardas",
-          "vis": "Vis",
-          "wages": "Salários",
-          "weapons": "Armas & Armaduras",
-          "woundsTotal": "Total de ferimentos",
-          "writingMaterials": "Materiais de escrita",
-          "xpcoeff": "Multiplicador de exp",
-          "xpmod": "Bônus de exp"
-        },
-        "type": {
-          "covenantBuildPoint": "Pontos de construção do concílio",
-          "covenantInhabitants": "Habitantes do concílio",
-          "spellcasting": "Conjuração",
-          "yearlyExpenses": "Despesas do concílio",
-          "yearlySavings": {
-            "magic": "Redução de custos mágica",
-            "mundane": "Redução de custos mundana"
-          }
-        },
-        "types": {
-          "AlternateArtBonus": "Bônus p/ Artes Alternativas",
-          "academicAbilitiesAffinity": "Afinidade c/ Hab. Acadêmicas (Exp)",
-          "academicAbilitiesBonus": "Bônus p/ Hab. Acadêmicas",
-          "affinityAlternateArt": "Afinidade c/ Artes Alternativas (Exp)",
-          "arcaneAbilitiesAffinity": "Afinidade c/ Hab. Arcanas (Exp)",
-          "arcaneAbilitiesBonus": "Bônus p/ Hab. Arcanas",
-          "arts": {
-            "affinity": "Afinidade com arte",
-            "deficiency": "Deficiência com arte"
-          },
-          "characteristics": "Características",
-          "fatigue": "Fadiga",
-          "formResistance": "Resistência natural",
-          "generalAbilitiesAffinity": "Afinidade c/ Hab. Gerais (Exp)",
-          "generalAbilitiesBonus": "Bônus p/ Hab. Gerais",
-          "labActivity": "Atividade de lab. do personagem",
-          "laboratoryAttr": "Características de Laboratório",
-          "laboratorySpec": "Especialidade de Laboratório",
-          "martialAbilitiesAffinity": "Afinidade c/ Hab. Marciais (Exp)",
-          "martialAbilitiesBonus": "Bônus p/ Hab. Marciais",
-          "mysteryAbilitiesAffinity": "Afinidade c/ Hab. de Mistério (Exp)",
-          "mysteryAbilitiesBonus": "Bônusp/ Hab. Mistério",
-          "nullEffect": "Efeito nulo",
-          "optional": "Bônus opcional",
-          "realmAlignment": "Alinhamento de Reino",
-          "roll": {
-            "optional": "Bônus de rolagem opcional"
-          },
-          "spellmastery": "Aperfeiçoamento de magia",
-          "supernaturalAbilitiesAffinity": "Afinidade c/ Hab. Sobrenaturais (Exp)",
-          "supernaturalAbilitiesBonus": "Bônus p/ Hab.Sobrenaturais",
-          "supernaturalAbilitiesXPBonus": "Bônus EXP de Hab. Sobrenaturais",
-          "vitals": "Vitas",
-          "wounds": "Ferimentos"
-        }
-      },
       "actuals": "Atual",
       "advanced": "Avançado",
       "advantage": "Vantagem",
@@ -1020,7 +1035,6 @@
       "constructionPoints": "Pontos de Construção",
       "consumables": "Consumíveis",
       "consumablesSumary": "2 libras p/ 10 pts de Habitantes (20% p/ ofício)",
-      "contestOfMagic": "Contestação de Magia",
       "cord": "Cordões",
       "cost": "Custo",
       "costSavings": "Reduções de Custos",
@@ -1307,17 +1321,6 @@
       "quickness": "Rapidez",
       "range": "Alcance",
       "rawVis": "Vis Bruto",
-      "realm": {
-        "divine": "Divino",
-        "faeric": "Feérico",
-        "infernal": "Infernal",
-        "label": "Reino",
-        "magic": "Mágico",
-        "mundane": "Mundano",
-        "nightModifier": "Modificador Noturno",
-        "visible": "Visível",
-        "visibleHint": "Mostrar ou esconder mod. de aura quando rolando"
-      },
       "refinement": "Refinamento",
       "religion": "Religião",
       "reputation": "Reputação",
@@ -1456,7 +1459,6 @@
       "totalExpenditure": "Despesas Totais",
       "totalHabitants": "Habitantes Totais",
       "totalIncome": "Renda Total",
-      "totalMagicResistance": "Total de resistência mágica",
       "totalPenetration": "Total de penetração",
       "trainingRequired": "Treinamento Necessário",
       "tribunal": "Tribunal",

--- a/module/actor/actor-laboratory-sheet.js
+++ b/module/actor/actor-laboratory-sheet.js
@@ -229,7 +229,7 @@ export class ArM5eLaboratoryActorSheet extends ArM5eActorSheet {
       context.edition.aura = "readonly";
       // context.planning.modifiers.aura += context.system.auraBonus;
       context.tooltip = {
-        aura: game.i18n.format("arm5e.sheet.activeEffect.add", {
+        aura: game.i18n.format("arm5e.activeEffect.add", {
           score: (context.system.auraBonus < 0 ? "" : "+") + context.system.auraBonus,
           value: game.i18n.localize("arm5e.sheet.aura")
         })

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -497,14 +497,14 @@ export class ArM5eActorSheet extends ActorSheet {
           if (technique.deficient) {
             technique.ui = {
               style: UI.STYLES.DEFICIENT_ART,
-              title: game.i18n.localize("arm5e.sheet.activeEffect.types.arts.deficiency")
+              title: game.i18n.localize("arm5e.activeEffect.types.arts.deficiency")
             };
           } else if (!technique.bonus && technique.xpCoeff == 1.0) {
             technique.ui = { style: UI.STYLES.STANDARD_ART };
           } else if (!technique.bonus && technique.xpCoeff != 1.0) {
             technique.ui = {
               style: UI.STYLES.AFINITY_ART,
-              title: game.i18n.localize("arm5e.sheet.activeEffect.types.arts.affinity")
+              title: game.i18n.localize("arm5e.activeEffect.types.arts.affinity")
             };
           } else if (technique.bonus && technique.xpCoeff == 1.0) {
             technique.ui = {
@@ -514,7 +514,7 @@ export class ArM5eActorSheet extends ActorSheet {
           } else {
             technique.ui = {
               style: UI.STYLES.COMBO_ART,
-              title: game.i18n.localize("arm5e.sheet.activeEffect.types.arts.affinity")
+              title: game.i18n.localize("arm5e.activeEffect.types.arts.affinity")
             };
           }
         }
@@ -544,14 +544,14 @@ export class ArM5eActorSheet extends ActorSheet {
           if (form.deficient) {
             form.ui = {
               style: UI.STYLES.DEFICIENT_ART,
-              title: game.i18n.localize("arm5e.sheet.activeEffect.types.arts.deficiency")
+              title: game.i18n.localize("arm5e.activeEffect.types.arts.deficiency")
             };
           } else if (!form.bonus && form.xpCoeff == 1.0) {
             form.ui = { style: UI.STYLES.STANDARD_ART };
           } else if (!form.bonus && form.xpCoeff != 1.0) {
             form.ui = {
               style: UI.STYLES.AFINITY_ART,
-              title: game.i18n.localize("arm5e.sheet.activeEffect.types.arts.affinity")
+              title: game.i18n.localize("arm5e.activeEffect.types.arts.affinity")
             };
           } else if (form.bonus && form.xpCoeff == 1.0) {
             form.ui = {
@@ -561,7 +561,7 @@ export class ArM5eActorSheet extends ActorSheet {
           } else {
             form.ui = {
               style: UI.STYLES.COMBO_ART,
-              title: game.i18n.localize("arm5e.sheet.activeEffect.types.arts.affinity")
+              title: game.i18n.localize("arm5e.activeEffect.types.arts.affinity")
             };
           }
 
@@ -599,13 +599,13 @@ export class ArM5eActorSheet extends ActorSheet {
                 context.system.labTotals[key][
                   k2
                 ].ui = `style="box-shadow: 0 0 5px blue" title="${game.i18n.localize(
-                  "arm5e.sheet.activeEffect.types.laboratorySpec"
+                  "arm5e.activeEffect.types.laboratorySpec"
                 )}: ${specialtyMod}"`;
               } else if (specialtyMod < 0) {
                 context.system.labTotals[key][
                   k2
                 ].ui = `style="box-shadow: 0 0 5px red" title="${game.i18n.localize(
-                  "arm5e.sheet.activeEffect.types.laboratorySpec"
+                  "arm5e.activeEffect.types.laboratorySpec"
                 )}: ${specialtyMod}"`;
               }
 

--- a/module/arm5e.js
+++ b/module/arm5e.js
@@ -271,7 +271,7 @@ Hooks.once("ready", async function () {
 
   if (game.release.generation == 13) {
     ui.notifications.info(game.i18n.localize("arm5e.system.V13Disclaimer"), {
-      permanent: true
+      permanent: false
     });
   }
 

--- a/module/config.js
+++ b/module/config.js
@@ -321,10 +321,10 @@ ARM5E.virtueFlawTypes.covenant = {
 
 ARM5E.qualityTypes = {
   mundane: {
-    label: "arm5e.sheet.realm.mundane"
+    label: "arm5e.realm.mundane"
   },
   magic: {
-    label: "arm5e.sheet.realm.magic"
+    label: "arm5e.realm.magic"
   }
 };
 
@@ -1218,22 +1218,22 @@ ARM5E.REALM_TYPES = {
 // influence is the impact the aura has on powers of mundane (ie: none), magic, faery, divine and infernal respectively
 ARM5E.realms = {
   magic: {
-    label: "arm5e.sheet.realm.magic",
+    label: "arm5e.realm.magic",
     index: ARM5E.REALM_TYPES.MAGIC,
     influence: [0, 1, 0.5, 0, -1]
   },
   faeric: {
-    label: "arm5e.sheet.realm.faeric",
+    label: "arm5e.realm.faeric",
     index: ARM5E.REALM_TYPES.FAERIC,
     influence: [0, 0.5, 1, 0, -1]
   },
   divine: {
-    label: "arm5e.sheet.realm.divine",
+    label: "arm5e.realm.divine",
     index: ARM5E.REALM_TYPES.DIVINE,
     influence: [0, -3, -4, 1, -5]
   },
   infernal: {
-    label: "arm5e.sheet.realm.infernal",
+    label: "arm5e.realm.infernal",
     index: ARM5E.REALM_TYPES.INFERNAL,
     influence: [0, -1, -2, 0, 1]
   }
@@ -1243,7 +1243,7 @@ ARM5E.lookupRealm = ["mundane", "magic", "faeric", "divine", "infernal"];
 
 ARM5E.realmsExt = {
   mundane: {
-    label: "arm5e.sheet.realm.mundane",
+    label: "arm5e.realm.mundane",
     index: 0,
     influence: [0, 0, 0, 0, 0]
   },

--- a/module/constants/activeEffectsTypes.js
+++ b/module/constants/activeEffectsTypes.js
@@ -24,6 +24,10 @@ export function addActiveEffectsDefinitions() {
     ...resistanceForms()
   };
 
+  ACTIVE_EFFECTS_TYPES.formMagicResistance.subtypes = {
+    ...magicResistanceForms()
+  };
+
   // Abilities related effects
 
   // Puissant abilities
@@ -529,6 +533,47 @@ export function addActiveEffectsDefinitions() {
       return a;
     }, {})
   };
+
+  ACTIVE_EFFECTS_TYPES.xpBonusAlternateArt.subtypes = {
+    ...Object.entries(ARM5E.ALT_TECHNIQUE_ABILITIES).reduce((a, current) => {
+      if (current[1].option) {
+        a[current[0]] = {
+          mnemonic: current[1].mnemonic,
+          key: `system.bonuses.skills.${current[0]}_#OPTION#.xpMod`,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          default: 5,
+          option: current[1].optionDefault
+        };
+      } else {
+        a[current[0]] = {
+          mnemonic: current[1].mnemonic,
+          key: `system.bonuses.skills.${current[0]}.xpMod`,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          default: 5
+        };
+      }
+      return a;
+    }, {}),
+    ...Object.entries(ARM5E.ALT_FORM_ABILITIES).reduce((a, current) => {
+      if (current[1].option) {
+        a[current[0]] = {
+          mnemonic: current[1].mnemonic,
+          key: `system.bonuses.skills.${current[0]}_#OPTION#.xpMod`,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          default: 5,
+          option: current[1].optionDefault
+        };
+      } else {
+        a[current[0]] = {
+          mnemonic: current[1].mnemonic,
+          key: `system.bonuses.skills.${current[0]}.xpMod`,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          default: 5
+        };
+      }
+      return a;
+    }, {})
+  };
 }
 
 const puissantTechniques = () => {
@@ -617,15 +662,27 @@ const resistanceForms = () => {
   }, {});
 };
 
+const magicResistanceForms = () => {
+  return Object.entries(ARM5E.magic.forms).reduce((a, current) => {
+    a[current[0]] = {
+      mnemonic: current[1].label,
+      key: `system.bonuses.magicResistance.${current[0]}`,
+      mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+      default: 0
+    };
+    return a;
+  }, {});
+};
+
 export const ACTIVE_EFFECTS_TYPES = {
   none: {
     category: "none",
     type: "none",
     tags: ["character", "covenant", "sanctum"],
-    mnemonic: "arm5e.sheet.activeEffect.types.nullEffect",
+    mnemonic: "arm5e.activeEffect.types.nullEffect",
     subtypes: {
       none: {
-        mnemonic: "arm5e.sheet.activeEffect.types.nullEffect",
+        mnemonic: "arm5e.activeEffect.types.nullEffect",
         key: "",
         mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM
       }
@@ -635,7 +692,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "spellcasting",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.type.spellcasting",
+    mnemonic: "arm5e.activeEffect.type.spellcasting",
     subtypes: {
       voiceLoud: {
         mnemonic: "arm5e.sheet.magic.voiceType.loud",
@@ -692,25 +749,31 @@ export const ACTIVE_EFFECTS_TYPES = {
         default: 2
       },
       spellFatigueThreshold: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.spellFatigueThreshold",
+        mnemonic: "arm5e.activeEffect.subtypes.spellFatigueThreshold",
         key: "system.bonuses.arts.spellFatigueThreshold",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: 10
       },
       ritualFatigueCancelled: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.ritualFatigueCancelled",
+        mnemonic: "arm5e.activeEffect.subtypes.ritualFatigueCancelled",
         key: "system.bonuses.arts.ritualFatigueCancelled",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: 0
+      },
+      magicResistance: {
+        mnemonic: "arm5e.activeEffect.subtypes.magicResistance",
+        key: "system.bonuses.arts.magicResistance",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 0
       }
       // spontDivider: {
-      //   mnemonic: "arm5e.sheet.activeEffect.subtypes.spontDivider",
+      //   mnemonic: "arm5e.activeEffect.subtypes.spontDivider",
       //   key: "system.bonuses.arts.spontDivider",
       //   mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
       //   default: 2
       // },
       // spontDividerNoFatigue: {
-      //   mnemonic: "arm5e.sheet.activeEffect.subtypes.spontDividerNoFatigue",
+      //   mnemonic: "arm5e.activeEffect.subtypes.spontDividerNoFatigue",
       //   key: "system.bonuses.arts.spontDividerNoFatigue",
       //   mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
       //   default: 5
@@ -723,7 +786,7 @@ export const ACTIVE_EFFECTS_TYPES = {
       //   // option: "mundane"
       // }
       // optional: {
-      //   mnemonic: "arm5e.sheet.activeEffect.types.optional",
+      //   mnemonic: "arm5e.activeEffect.types.optional",
       //   key: "system.bonuses.arts.spellcasting",
       //   mode: CONST.ACTIVE_EFFECT_MODES.ADD,
       //   default: 0,
@@ -804,16 +867,16 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "spellmastery",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.spellmastery",
+    mnemonic: "arm5e.activeEffect.types.spellmastery",
     subtypes: {
       xpCoeff: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.xpcoeff",
+        mnemonic: "arm5e.activeEffect.subtypes.xpcoeff",
         key: "system.bonuses.arts.masteryXpCoeff",
         mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
         default: 2.0
       },
       xpMod: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.xpmod",
+        mnemonic: "arm5e.activeEffect.subtypes.xpmod",
         key: "system.bonuses.arts.masteryXpMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 5
@@ -833,7 +896,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "affinity",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.arts.affinity",
+    mnemonic: "arm5e.activeEffect.types.arts.affinity",
     subtypes: {
       // added dynamically
     }
@@ -842,7 +905,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "artDeficiency",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.arts.deficiency",
+    mnemonic: "arm5e.activeEffect.types.arts.deficiency",
     subtypes: {
       // added dynamically
     }
@@ -851,7 +914,16 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "traits",
     type: "formResistance",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.formResistance",
+    mnemonic: "arm5e.activeEffect.types.formResistance",
+    subtypes: {
+      // added dynamically
+    }
+  },
+  formMagicResistance: {
+    category: "traits",
+    type: "formMagicResistance",
+    tags: ["character"],
+    mnemonic: "arm5e.activeEffect.types.formMagicResistance",
     subtypes: {
       // added dynamically
     }
@@ -860,7 +932,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "traits",
     type: "vitals",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.vitals",
+    mnemonic: "arm5e.activeEffect.types.vitals",
     subtypes: {
       size: {
         mnemonic: "arm5e.sheet.size",
@@ -910,7 +982,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "traits",
     type: "characteristics",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.characteristics",
+    mnemonic: "arm5e.activeEffect.types.characteristics",
     subtypes: {
       int: {
         mnemonic: "arm5e.sheet.intelligence",
@@ -972,7 +1044,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "traits",
     type: "characteristics",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.characteristicBoost",
+    mnemonic: "arm5e.activeEffect.types.characteristicBoost",
     subtypes: {
       int: {
         mnemonic: "arm5e.sheet.intelligence",
@@ -1034,10 +1106,10 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "traits",
     type: "fatigue",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.fatigue",
+    mnemonic: "arm5e.activeEffect.types.fatigue",
     subtypes: {
       total: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.fatigueTotal",
+        mnemonic: "arm5e.activeEffect.subtypes.fatigueTotal",
         key: "system.bonuses.traits.fatigue",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 0
@@ -1096,10 +1168,10 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "traits",
     type: "wounds",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.wounds",
+    mnemonic: "arm5e.activeEffect.types.wounds",
     subtypes: {
       total: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.woundsTotal",
+        mnemonic: "arm5e.activeEffect.subtypes.woundsTotal",
         key: "system.bonuses.traits.wounds",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 0
@@ -1128,28 +1200,28 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "realm",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.realmAlignment",
+    mnemonic: "arm5e.activeEffect.types.realmAlignment",
     subtypes: {
       magic: {
-        mnemonic: "arm5e.sheet.realm.magic",
+        mnemonic: "arm5e.realm.magic",
         key: "system.realms.magic.aligned",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
       },
       faeric: {
-        mnemonic: "arm5e.sheet.realm.faeric",
+        mnemonic: "arm5e.realm.faeric",
         key: "system.realms.faeric.aligned",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
       },
       divine: {
-        mnemonic: "arm5e.sheet.realm.divine",
+        mnemonic: "arm5e.realm.divine",
         key: "system.realms.divine.aligned",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
       },
       infernal: {
-        mnemonic: "arm5e.sheet.realm.infernal",
+        mnemonic: "arm5e.realm.infernal",
         key: "system.realms.infernal.aligned",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
@@ -1160,28 +1232,28 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "realmSusceptibility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.realmSusceptibility",
+    mnemonic: "arm5e.activeEffect.types.realmSusceptibility",
     subtypes: {
       magic: {
-        mnemonic: "arm5e.sheet.realm.magic",
+        mnemonic: "arm5e.realm.magic",
         key: "system.realms.magic.susceptible",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
       },
       faeric: {
-        mnemonic: "arm5e.sheet.realm.faeric",
+        mnemonic: "arm5e.realm.faeric",
         key: "system.realms.faeric.susceptible",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
       },
       divine: {
-        mnemonic: "arm5e.sheet.realm.divine",
+        mnemonic: "arm5e.realm.divine",
         key: "system.realms.divine.susceptible",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
       },
       infernal: {
-        mnemonic: "arm5e.sheet.realm.infernal",
+        mnemonic: "arm5e.realm.infernal",
         key: "system.realms.infernal.susceptible",
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
         default: true
@@ -1219,7 +1291,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusGeneralAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.generalAbilitiesBonus",
+    mnemonic: "arm5e.activeEffect.types.generalAbilitiesBonus",
     subtypes: {
       // add dynamically
     }
@@ -1228,7 +1300,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusAcademicAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.academicAbilitiesBonus",
+    mnemonic: "arm5e.activeEffect.types.academicAbilitiesBonus",
     subtypes: {
       // add dynamically
     }
@@ -1237,7 +1309,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusArcaneAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.arcaneAbilitiesBonus",
+    mnemonic: "arm5e.activeEffect.types.arcaneAbilitiesBonus",
     subtypes: {
       // add dynamically
     }
@@ -1247,7 +1319,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusMartialAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.martialAbilitiesBonus",
+    mnemonic: "arm5e.activeEffect.types.martialAbilitiesBonus",
     subtypes: {
       // add dynamically
     }
@@ -1256,7 +1328,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusMysteryAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.mysteryAbilitiesBonus",
+    mnemonic: "arm5e.activeEffect.types.mysteryAbilitiesBonus",
     subtypes: {
       // add dynamically
     }
@@ -1265,7 +1337,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusSupernaturalAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.supernaturalAbilitiesBonus",
+    mnemonic: "arm5e.activeEffect.types.supernaturalAbilitiesBonus",
     subtypes: {
       // add dynamically
     }
@@ -1274,7 +1346,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "bonusAlternateArt",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.AlternateArtBonus",
+    mnemonic: "arm5e.activeEffect.types.AlternateArtBonus",
     subtypes: {
       // add dynamically
     }
@@ -1284,7 +1356,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "xpBonusGeneralAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.generalAbilitiesXPBonus",
+    mnemonic: "arm5e.activeEffect.types.generalAbilitiesXPBonus",
     subtypes: {
       // add dynamically
     }
@@ -1294,7 +1366,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "xpBonusAcademicAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.academicAbilitiesXPBonus",
+    mnemonic: "arm5e.activeEffect.types.academicAbilitiesXPBonus",
     subtypes: {
       // add dynamically
     }
@@ -1304,7 +1376,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "xpBonusArcaneAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.arcaneAbilitiesXPBonus",
+    mnemonic: "arm5e.activeEffect.types.arcaneAbilitiesXPBonus",
     subtypes: {
       // add dynamically
     }
@@ -1314,7 +1386,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "xpBonusMartialAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.martialAbilitiesXPBonus",
+    mnemonic: "arm5e.activeEffect.types.martialAbilitiesXPBonus",
     subtypes: {
       // add dynamically
     }
@@ -1324,7 +1396,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "xpBonusSupernaturalAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.supernaturalAbilitiesXPBonus",
+    mnemonic: "arm5e.activeEffect.types.supernaturalAbilitiesXPBonus",
     subtypes: {
       // add dynamically
     }
@@ -1333,7 +1405,17 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "xpBonusMysteryAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.mysteryAbilitiesXPBonus",
+    mnemonic: "arm5e.activeEffect.types.mysteryAbilitiesXPBonus",
+    subtypes: {
+      // add dynamically
+    }
+  },
+
+  xpBonusAlternateArt: {
+    category: "abilities",
+    type: "xpBonusAlternateArt",
+    tags: ["character"],
+    mnemonic: "arm5e.activeEffect.types.AlternateArtXPBonus",
     subtypes: {
       // add dynamically
     }
@@ -1342,7 +1424,7 @@ export const ACTIVE_EFFECTS_TYPES = {
   // xpBonusMysticalAbility: {
   //   category: "abilities",
   //   type: "xpBonusMysticalAbility",
-  //   mnemonic: "arm5e.sheet.activeEffect.types.supernaturalAbilitiesXPBonus",
+  //   mnemonic: "arm5e.activeEffect.types.supernaturalAbilitiesXPBonus",
   //   subtypes: {
   //     heartbeast: {
   //       mnemonic: "arm5e.skill.mystical.heartbeast",
@@ -1358,7 +1440,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "qualityAbilityBoost",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.qualityAbilityBoost",
+    mnemonic: "arm5e.activeEffect.types.qualityAbilityBoost",
     subtypes: {
       athletics: {
         mnemonic: "arm5e.skill.general.athletics",
@@ -1420,7 +1502,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinityGeneralAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.generalAbilitiesAffinity",
+    mnemonic: "arm5e.activeEffect.types.generalAbilitiesAffinity",
     subtypes: {
       // add dynamically
     }
@@ -1429,7 +1511,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinityArcaneAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.arcaneAbilitiesAffinity",
+    mnemonic: "arm5e.activeEffect.types.arcaneAbilitiesAffinity",
     subtypes: {
       // add dynamically
     }
@@ -1438,7 +1520,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinityAcademicAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.academicAbilitiesAffinity",
+    mnemonic: "arm5e.activeEffect.types.academicAbilitiesAffinity",
     subtypes: {
       // add dynamically
     }
@@ -1447,7 +1529,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinityMartialAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.martialAbilitiesAffinity",
+    mnemonic: "arm5e.activeEffect.types.martialAbilitiesAffinity",
     subtypes: {
       // add dynamically
     }
@@ -1456,7 +1538,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinityMysteryAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.mysteryAbilitiesAffinity",
+    mnemonic: "arm5e.activeEffect.types.mysteryAbilitiesAffinity",
     subtypes: {
       // add dynamically
     }
@@ -1465,7 +1547,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinitySupernaturalAbility",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.supernaturalAbilitiesAffinity",
+    mnemonic: "arm5e.activeEffect.types.supernaturalAbilitiesAffinity",
     subtypes: {
       // add dynamicallyv
     }
@@ -1474,7 +1556,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "abilities",
     type: "affinityAlternateArt",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.affinityAlternateArt",
+    mnemonic: "arm5e.activeEffect.types.affinityAlternateArt",
     subtypes: {
       // add dynamically
     }
@@ -1484,7 +1566,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "magic",
     type: "laboratory",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.labActivity",
+    mnemonic: "arm5e.activeEffect.types.labActivity",
     subtypes: {
       learnSpell: {
         mnemonic: "arm5e.lab.activity.spellLearning",
@@ -1504,7 +1586,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "laboratory",
     type: "laboratorySpec",
     tags: ["sanctum"],
-    mnemonic: "arm5e.sheet.activeEffect.types.laboratorySpec",
+    mnemonic: "arm5e.activeEffect.types.laboratorySpec",
     subtypes: {
       texts: {
         mnemonic: "arm5e.lab.specialty.texts",
@@ -1644,7 +1726,7 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "laboratory",
     type: "laboratory",
     tags: ["sanctum"],
-    mnemonic: "arm5e.sheet.activeEffect.types.laboratoryAttr",
+    mnemonic: "arm5e.activeEffect.types.laboratoryAttr",
     subtypes: {
       size: {
         mnemonic: "arm5e.sheet.size",
@@ -1713,34 +1795,34 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "roll",
     type: "optionalRollBonus",
     tags: ["character"],
-    mnemonic: "arm5e.sheet.activeEffect.types.roll.optional",
+    mnemonic: "arm5e.activeEffect.types.roll.optional",
     subtypes: {
       spontMagic: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.spontMagicRoll",
+        mnemonic: "arm5e.activeEffect.subtypes.spontMagicRoll",
         key: "spontMagic",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 3
       },
       formulaicMagic: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.formMagicRoll",
+        mnemonic: "arm5e.activeEffect.subtypes.formMagicRoll",
         key: "formulaicMagic",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 3
       },
       init: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.initRoll",
+        mnemonic: "arm5e.activeEffect.subtypes.initRoll",
         key: "init",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 3
       },
       attack: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.attackRoll",
+        mnemonic: "arm5e.activeEffect.subtypes.attackRoll",
         key: "attack",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 3
       },
       defense: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.defRoll",
+        mnemonic: "arm5e.activeEffect.subtypes.defRoll",
         key: "defense",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 3
@@ -1751,46 +1833,46 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "covenant",
     type: "buildPoints",
     tags: ["covenant"],
-    mnemonic: "arm5e.sheet.activeEffect.type.covenantBuildPoint",
+    mnemonic: "arm5e.activeEffect.type.covenantBuildPoint",
     subtypes: {
       library: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.library",
+        mnemonic: "arm5e.activeEffect.subtypes.library",
         key: "system.buildPoints.library.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
       },
       labText: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.labText",
+        mnemonic: "arm5e.activeEffect.subtypes.labText",
         key: "system.buildPoints.labText.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
       },
       vis: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.vis",
+        mnemonic: "arm5e.activeEffect.subtypes.vis",
         key: "system.buildPoints.vis.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
       },
       magicItems: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.magicItems",
+        mnemonic: "arm5e.activeEffect.subtypes.magicItems",
         key: "system.buildPoints.magicItems.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
       },
       specialists: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.specialists",
+        mnemonic: "arm5e.activeEffect.subtypes.specialists",
         key: "system.buildPoints.specialists.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
       },
       labs: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.labs",
+        mnemonic: "arm5e.activeEffect.subtypes.labs",
         key: "system.buildPoints.labs.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
       },
       money: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.money",
+        mnemonic: "arm5e.activeEffect.subtypes.money",
         key: "system.buildPoints.money.computed",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 10
@@ -1801,52 +1883,52 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "covenant",
     type: "expenses",
     tags: ["covenant"],
-    mnemonic: "arm5e.sheet.activeEffect.type.yearlyExpenses",
+    mnemonic: "arm5e.activeEffect.type.yearlyExpenses",
     subtypes: {
       inhabitant: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.inhabitantPoints",
+        mnemonic: "arm5e.activeEffect.subtypes.inhabitantPoints",
         key: "system.finances.inhabitantsPoints",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       buildings: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.buildings",
+        mnemonic: "arm5e.activeEffect.subtypes.buildings",
         key: "system.yearlyExpenses.buildings.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       consumables: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.consumables",
+        mnemonic: "arm5e.activeEffect.subtypes.consumables",
         key: "system.yearlyExpenses.consumables.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       provisions: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.provisions",
+        mnemonic: "arm5e.activeEffect.subtypes.provisions",
         key: "system.yearlyExpenses.provisions.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       wages: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.wages",
+        mnemonic: "arm5e.activeEffect.subtypes.wages",
         key: "system.yearlyExpenses.wages.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       laboratories: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.laboratories",
+        mnemonic: "arm5e.activeEffect.subtypes.laboratories",
         key: "system.yearlyExpenses.laboratories.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       books: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.writingMaterials",
+        mnemonic: "arm5e.activeEffect.subtypes.writingMaterials",
         key: "system.yearlyExpenses.writingMaterials.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       weapons: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.weapons",
+        mnemonic: "arm5e.activeEffect.subtypes.weapons",
         key: "system.yearlyExpenses.weapons.amount",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
@@ -1857,46 +1939,46 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "covenant",
     type: "savingsMundane",
     tags: ["covenant"],
-    mnemonic: "arm5e.sheet.activeEffect.type.yearlySavings.mundane",
+    mnemonic: "arm5e.activeEffect.type.yearlySavings.mundane",
     subtypes: {
       buildings: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.buildings",
+        mnemonic: "arm5e.activeEffect.subtypes.buildings",
         key: "system.yearlyExpenses.buildings.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       consumables: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.consumables",
+        mnemonic: "arm5e.activeEffect.subtypes.consumables",
         key: "system.yearlyExpenses.consumables.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       provisions: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.provisions",
+        mnemonic: "arm5e.activeEffect.subtypes.provisions",
         key: "system.yearlyExpenses.provisions.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       wages: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.wages",
+        mnemonic: "arm5e.activeEffect.subtypes.wages",
         key: "system.yearlyExpenses.wages.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       laboratories: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.laboratories",
+        mnemonic: "arm5e.activeEffect.subtypes.laboratories",
         key: "system.yearlyExpenses.laboratories.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       writingMaterials: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.writingMaterials",
+        mnemonic: "arm5e.activeEffect.subtypes.writingMaterials",
         key: "system.yearlyExpenses.writingMaterials.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       weapons: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.weapons",
+        mnemonic: "arm5e.activeEffect.subtypes.weapons",
         key: "system.yearlyExpenses.weapons.mod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
@@ -1907,46 +1989,46 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "covenant",
     type: "savingsMagic",
     tags: ["covenant"],
-    mnemonic: "arm5e.sheet.activeEffect.type.yearlySavings.magic",
+    mnemonic: "arm5e.activeEffect.type.yearlySavings.magic",
     subtypes: {
       buildings: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.buildings",
+        mnemonic: "arm5e.activeEffect.subtypes.buildings",
         key: "system.yearlyExpenses.buildings.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       consumables: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.consumables",
+        mnemonic: "arm5e.activeEffect.subtypes.consumables",
         key: "system.yearlyExpenses.consumables.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       provisions: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.provisions",
+        mnemonic: "arm5e.activeEffect.subtypes.provisions",
         key: "system.yearlyExpenses.provisions.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       wages: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.wages",
+        mnemonic: "arm5e.activeEffect.subtypes.wages",
         key: "system.yearlyExpenses.wages.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       laboratories: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.laboratories",
+        mnemonic: "arm5e.activeEffect.subtypes.laboratories",
         key: "system.yearlyExpenses.laboratories.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       writingMaterials: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.writingMaterials",
+        mnemonic: "arm5e.activeEffect.subtypes.writingMaterials",
         key: "system.yearlyExpenses.writingMaterials.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       weapons: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.weapons",
+        mnemonic: "arm5e.activeEffect.subtypes.weapons",
         key: "system.yearlyExpenses.weapons.magicMod",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
@@ -1957,28 +2039,28 @@ export const ACTIVE_EFFECTS_TYPES = {
     category: "covenant",
     type: "covenantInhabitants",
     tags: ["covenant"],
-    mnemonic: "arm5e.sheet.activeEffect.type.covenantInhabitants",
+    mnemonic: "arm5e.activeEffect.type.covenantInhabitants",
     subtypes: {
       turbula: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.turbula",
+        mnemonic: "arm5e.activeEffect.subtypes.turbula",
         key: "system.census.turbula",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       laborers: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.laborers",
+        mnemonic: "arm5e.activeEffect.subtypes.laborers",
         key: "system.census.laborers",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       teamsters: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.teamsters",
+        mnemonic: "arm5e.activeEffect.subtypes.teamsters",
         key: "system.census.teamsters",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2
       },
       servants: {
-        mnemonic: "arm5e.sheet.activeEffect.subtypes.servants",
+        mnemonic: "arm5e.activeEffect.subtypes.servants",
         key: "system.census.servants",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 2

--- a/module/dice.js
+++ b/module/dice.js
@@ -624,7 +624,7 @@ async function getRollFormula(actor) {
       msg += "<br/>";
       msg += game.i18n.localize("arm5e.messages.die.divideBy") + rollInfo.magic.divide;
       if (rollInfo.magic.technique.deficiency || rollInfo.magic.form.deficiency) {
-        msg += ` (${game.i18n.localize("arm5e.sheet.activeEffect.types.arts.deficiency")})`;
+        msg += ` (${game.i18n.localize("arm5e.activeEffect.types.arts.deficiency")})`;
       }
     }
 
@@ -979,15 +979,15 @@ async function noRoll(actor, modes, callback) {
 }
 
 async function changeMight(actor, roll, message) {
-  const form = CONFIG.ARM5E.magic.arts[actor.rollInfo.power.form]?.label ?? "NONE";
-  await handleTargetsOfMagic(actor, form, message);
+  // const form = CONFIG.ARM5E.magic.arts[actor.rollInfo.power.form]?.label ?? "NONE";
+  await handleTargetsOfMagic(actor, actor.rollInfo.power.form, message);
   await actor.changeMight(-actor.rollInfo.power.cost);
 }
 
 async function useItemCharge(actor, roll, message) {
-  const form = CONFIG.ARM5E.magic.arts[actor.rollInfo.item.form]?.label ?? "NONE";
+  // const form = CONFIG.ARM5E.magic.arts[actor.rollInfo.item.form]?.label ?? "NONE";
   const item = actor.items.get(actor.rollInfo.item.id);
-  await handleTargetsOfMagic(actor, form, message);
+  await handleTargetsOfMagic(actor, actor.rollInfo.item.form, message);
   await item.useItemCharge();
 }
 export { simpleDie, stressDie, noRoll, changeMight, useItemCharge };

--- a/module/helpers/active-effect-config.sheet.js
+++ b/module/helpers/active-effect-config.sheet.js
@@ -104,7 +104,7 @@ export class ArM5eActiveEffectConfig extends ActiveEffectConfig {
         }
         subType.computedKey = tmp;
 
-        subType.modeStr = "arm5e.sheet.activeEffect.mode_" + subType.mode;
+        subType.modeStr = "arm5e.activeEffect.mode_" + subType.mode;
 
         subTypes.push(subType);
         if (k == context.selectedSubtypes[idx]) {

--- a/module/helpers/active-effects.js
+++ b/module/helpers/active-effects.js
@@ -79,7 +79,7 @@ export default class ArM5eActiveEffect extends ActiveEffect {
           }
         };
 
-        data.name = game.i18n.localize("arm5e.sheet.activeEffect.new");
+        data.name = game.i18n.localize("arm5e.activeEffect.new");
         data.img = "icons/svg/aura.svg";
 
         return await owner.createEmbeddedDocuments("ActiveEffect", [data]);
@@ -103,17 +103,17 @@ export default class ArM5eActiveEffect extends ActiveEffect {
     const categories = {
       temporary: {
         type: "temporary",
-        label: "arm5e.sheet.activeEffect.section.temporary",
+        label: "arm5e.activeEffect.section.temporary",
         effects: []
       },
       passive: {
         type: "passive",
-        label: "arm5e.sheet.activeEffect.section.passive",
+        label: "arm5e.activeEffect.section.passive",
         effects: []
       },
       inactive: {
         type: "inactive",
-        label: "arm5e.sheet.activeEffect.section.inactive",
+        label: "arm5e.activeEffect.section.inactive",
         effects: []
       }
     };
@@ -261,7 +261,7 @@ export default class ArM5eActiveEffect extends ActiveEffect {
               subtype = game.i18n.format(subtype, { option: effectOption[idx] });
             }
             descr +=
-              game.i18n.format("arm5e.sheet.activeEffect.multiply", {
+              game.i18n.format("arm5e.activeEffect.multiply", {
                 type: subtype
               }) +
               (c.value < 0 ? "" : "+") +
@@ -271,7 +271,7 @@ export default class ArM5eActiveEffect extends ActiveEffect {
             if (effectOption[idx]) {
               subtype = game.i18n.format(subtype, { option: effectOption[idx] });
             }
-            descr += game.i18n.format("arm5e.sheet.activeEffect.add", {
+            descr += game.i18n.format("arm5e.activeEffect.add", {
               score: (c.value < 0 ? "" : "+") + c.value,
               value: subtype
             });

--- a/module/helpers/rollInfo.js
+++ b/module/helpers/rollInfo.js
@@ -296,12 +296,7 @@ export class ArM5eRollInfo {
           enigma: this._actor.getAbilityStats("enigma")
         };
         this.twilight.enigma.specApply = false;
-        this.setGenericField(
-          game.i18n.localize("arm5e.twilight.warpingPoints"),
-          dataset.warpingPts ?? 2,
-          2,
-          "+"
-        );
+
         this.setGenericField(
           game.i18n.localize("arm5e.skill.mystery.enigma"),
           this.twilight.enigma.score,
@@ -508,7 +503,7 @@ export class ArM5eRollInfo {
     );
 
     this.selection.abilities = {
-      None: game.i18n.localize("arm5e.sheet.activeEffect.subtypes.none"),
+      None: game.i18n.localize("arm5e.activeEffect.subtypes.none"),
       ...Object.fromEntries(
         this._actor.system.abilities.map((a) => {
           return [a._id, `${a.name} (${a.system.finalScore})`];

--- a/module/helpers/rollWindow.js
+++ b/module/helpers/rollWindow.js
@@ -150,7 +150,7 @@ const ROLL_PROPERTIES = {
   },
   TWILIGHT_CONTROL: {
     VAL: "twilight_control",
-    MODE: 25, // STRESS  + NO_CONF + UNCONSCIOUS
+    MODE: 17, // STRESS + UNCONSCIOUS
     MODIFIERS: 1,
     TITLE: "arm5e.twilight.episode",
     ACTION_LABEL: "arm5e.twilight.control.avoid",
@@ -172,7 +172,7 @@ const ROLL_PROPERTIES = {
   },
   TWILIGHT_UNDERSTANDING: {
     VAL: "twilight_understanding",
-    MODE: 25, // STRESS  + NO_CONF + UNCONSCIOUS
+    MODE: 17, // STRESS  + UNCONSCIOUS
     MODIFIERS: 1,
     TITLE: "arm5e.twilight.episode",
     CALLBACK: twilightUnderstanding
@@ -804,9 +804,9 @@ async function castSpell(actorCaster, roll, message) {
   const updateImpact = await _applyImpact(actorCaster, roll, message);
   foundry.utils.mergeObject(updateData, updateImpact);
 
-  const form = CONFIG.ARM5E.magic.arts[actorCaster.rollInfo.magic.form.value]?.label ?? "NONE";
+  // const form = CONFIG.ARM5E.magic.arts[actorCaster.rollInfo.magic.form.value]?.label ?? "NONE";
   await actorCaster.update(updateData);
-  await handleTargetsOfMagic(actorCaster, form, message);
+  await handleTargetsOfMagic(actorCaster, actorCaster.rollInfo.magic.form.value, message);
   message.updateSource(messageUpdate);
   // Then do contest of magic
 }
@@ -844,8 +844,8 @@ async function castSupernaturalEffect(actorCaster, roll, message) {
 
   message.updateSource(messageUpdate);
   // Then do contest of magic
-  const form = CONFIG.ARM5E.magic.arts[actorCaster.rollInfo.magic.form.value]?.label ?? "NONE";
-  await handleTargetsOfMagic(actorCaster, form, message);
+  // const form = CONFIG.ARM5E.magic.arts[actorCaster.rollInfo.magic.form.value]?.label ?? "NONE";
+  await handleTargetsOfMagic(actorCaster, actorCaster.rollInfo.magic.form.value, message);
 }
 
 /**

--- a/module/helpers/rollWindow.js
+++ b/module/helpers/rollWindow.js
@@ -731,34 +731,28 @@ async function _applyImpact(actor, roll, message) {
 
       defaultImpact.woundGravity = res.woundGravity;
     }
-
-    // the actor can still change the situation by spending confidence.
-    if (actor.canUseConfidencePoint() && message.system.confidence.allowed && !roll.botches) {
-      // do not update fatigue yet.
-      delete updateData["system.fatigueCurrent"];
-      if (
-        defaultImpact.fatigueLevelsPending ||
-        defaultImpact.fatigueLevelsFail ||
-        defaultImpact.woundGravity
-      ) {
-        updateData["system.states.confidencePrompt"] = true;
-      }
-    } else {
-      if (defaultImpact.woundGravity) {
-        await actor.changeWound(
-          1,
-          CONFIG.ARM5E.recovery.rankMapping[defaultImpact.woundGravity],
-          game.i18n.localize("arm5e.sheet.fatigueOverflow")
-        );
-      }
-      defaultImpact.fatigueLevelsLost +=
-        defaultImpact.fatigueLevelsPending + defaultImpact.fatigueLevelsFail;
-      defaultImpact.fatigueLevelsPending = 0;
-      defaultImpact.fatigueLevelsFail = 0;
-      defaultImpact.applied = true;
-    }
-    messageUpdate["system.impact"] = defaultImpact;
   }
+  // the actor can still change the situation by spending confidence.
+  if (actor.canUseConfidencePoint() && message.system.confidence.allowed && !roll.botches) {
+    // do not update fatigue yet.
+    delete updateData["system.fatigueCurrent"];
+    updateData["system.states.confidencePrompt"] = true;
+  } else {
+    if (defaultImpact.woundGravity) {
+      await actor.changeWound(
+        1,
+        CONFIG.ARM5E.recovery.rankMapping[defaultImpact.woundGravity],
+        game.i18n.localize("arm5e.sheet.fatigueOverflow")
+      );
+    }
+    defaultImpact.fatigueLevelsLost +=
+      defaultImpact.fatigueLevelsPending + defaultImpact.fatigueLevelsFail;
+    defaultImpact.fatigueLevelsPending = 0;
+    defaultImpact.fatigueLevelsFail = 0;
+    defaultImpact.applied = true;
+  }
+  messageUpdate["system.impact"] = defaultImpact;
+
   message.updateSource(messageUpdate);
   log(false, "_applyImpact impact", message.system.impact);
   return updateData;

--- a/module/migration.js
+++ b/module/migration.js
@@ -398,6 +398,13 @@ export const migrateActorData = async function (actorDoc, actorItems) {
       if (actor.system.charType && actor.system.charType.value === undefined) {
         updateData["system.charType"] = { value: actor.system.charType };
       }
+      if (actor.system.states === undefined) {
+        updateData["system.states"] = {
+          pendingCrisis: false,
+          creationMode: false,
+          confidencePrompt: false
+        };
+      }
 
       if (actor.system.pendingCrisis) {
         updateData["system.states.pendingCrisis"] = true;

--- a/module/schemas/chatSchema.js
+++ b/module/schemas/chatSchema.js
@@ -97,7 +97,7 @@ export class RollChatSchema extends BasicChatSchema {
         }),
         secondaryScore: basicIntegerField(0),
         divider: basicIntegerField(1, 1),
-        difficulty: basicIntegerField(1, 0)
+        difficulty: basicIntegerField(0, 0)
       }),
       impact: new fields.SchemaField(
         {
@@ -172,7 +172,7 @@ export class RollChatSchema extends BasicChatSchema {
       formula += ` + ${toAppend}`;
     }
 
-    if (this.roll.difficulty) {
+    if (this.roll.difficulty && this.roll.botches === 0) {
       formula += ` versus ${this.roll.difficulty}`;
     }
     return formula;

--- a/module/schemas/chatSchema.js
+++ b/module/schemas/chatSchema.js
@@ -735,39 +735,50 @@ export class MagicChatSchema extends RollChatSchema {
 
   getTargetsHtml() {
     let res = "";
+    const rollType = this.roll.type;
     for (let target of this.magic.targets) {
-      const title =
-        '<h3 class="ars-chat-title">' + game.i18n.localize("arm5e.sheet.contestOfMagic") + "</h3>";
-      const castingTotal = `${game.i18n.localize("arm5e.sheet.spellTotal")} (${
-        this.parent.rollTotal + this.confidenceModifier
-      })`;
+      const title = `<h3 class="ars-chat-title"> + ${game.i18n.format(
+        "arm5e.chat.contestOfMagicWith",
+        { name: target.name }
+      )} </h3>`;
+      let castingTotal = "";
+      if (!["item", "power"].includes(rollType)) {
+        castingTotal = `${game.i18n.localize("arm5e.sheet.spellTotal")} (${
+          this.parent.rollTotal + this.confidenceModifier
+        })`;
+      }
 
       const showDetails =
         game.user.isGM || game.settings.get("arm5e", "showNPCMagicDetails") === "SHOW_ALL";
       // penetration
       let flavorTotalSpell = "";
       let flavorTotalPenetration = "";
+      let magicLevel = "";
+      let penetration = "";
+      let penetrationSpec = "";
       if (showDetails || this.magic.caster.hasPlayerOwner) {
-        const magicLevel = `- ${game.i18n.localize("arm5e.sheet.spellLevel")} (${
-          this.roll.difficulty
-        })`;
-        const penetration = `+ ${game.i18n.localize("arm5e.sheet.penetration")} (${
-          this.magic.caster.penetration.total
-        })`;
-
-        const penetrationSpec = this.magic.caster.penetration.specApply
-          ? ` (${game.i18n.localize("arm5e.sheet.specialityBonus")}: +1 ${
-              this.magic.caster.penetration.specialty
-            })`
-          : "";
-
         const totalPenetration = `+ ${game.i18n.localize("arm5e.sheet.totalPenetration")} (${
           this.roll.secondaryScore + this.parent.rollTotal - this.roll.difficulty
         })`;
+        if (["item", "power"].includes(rollType)) {
+          flavorTotalPenetration = `<b>${totalPenetration}</b><br/>`;
+          flavorTotalSpell = "";
+        } else {
+          magicLevel = `- ${game.i18n.localize("arm5e.sheet.spellLevel")} (${
+            this.roll.difficulty
+          })`;
+          penetration = `+ ${game.i18n.localize("arm5e.sheet.penetration")} (${
+            this.magic.caster.penetration.total
+          })`;
 
-        flavorTotalPenetration = `${penetration}${penetrationSpec}<br/><b>${totalPenetration}</b><br/>`;
-
-        flavorTotalSpell = `${castingTotal}<br/> ${magicLevel}<br/>`;
+          penetrationSpec = this.magic.caster.penetration.specApply
+            ? ` (${game.i18n.localize("arm5e.sheet.specialityBonus")}: +1 ${
+                this.magic.caster.penetration.specialty
+              })`
+            : "";
+          flavorTotalSpell = `${castingTotal}<br/> ${magicLevel}<br/>`;
+          flavorTotalPenetration = `${penetration}${penetrationSpec}<br/><b>${totalPenetration}</b><br/>`;
+        }
       }
 
       let flavorTotalMagicResistance = "";
@@ -776,38 +787,52 @@ export class MagicChatSchema extends RollChatSchema {
         const might = target.magicResistance.might
           ? `${game.i18n.localize("arm5e.sheet.might")}: (${target.magicResistance.might})`
           : "";
-        const form =
-          target.magicResistance.form !== "NONE"
-            ? `+ ${game.i18n.format("arm5e.sheet.formScore", {
-                form: target.magicResistance.form
-              })}: (${target.magicResistance.formScore})`
-            : "";
+
+        let form = "";
+        if (target.magicResistance.formScore) {
+          if (target.magicResistance.form !== "NONE") {
+            form = `+ ${game.i18n.format("arm5e.sheet.formScore", {
+              form: target.magicResistance.form
+            })}: (${target.magicResistance.formScore})`;
+          }
+        }
 
         const aura =
           target.magicResistance.aura == 0
             ? ""
             : ` + ${game.i18n.localize("arm5e.sheet.aura")}: (${target.magicResistance.aura})`;
 
-        const parma = target.magicResistance?.parma?.score
-          ? `${game.i18n.localize("arm5e.sheet.parma")}: (${target.magicResistance.parma.score})`
+        // if there is another resistance, it i
+        const parma = target.magicResistance.parma
+          ? ` + ${game.i18n.localize("arm5e.sheet.parma")}: (${
+              target.magicResistance.parma.score * 5
+            })`
           : "";
 
-        const parmaSpecialty = target.magicResistance?.specialityIncluded
-          ? ` (${game.i18n.localize("arm5e.sheet.specialityBonus")}: +1 ${
+        const parmaSpecialty = target.magicResistance.specialityIncluded
+          ? ` (${game.i18n.localize("arm5e.sheet.specialityBonus")}: +5 ${
               target.magicResistance.specialityIncluded
             })`
           : "";
 
         const susceptibility = target.magicResistance.susceptible
-          ? `${game.i18n.format("arm5e.sheet.realm.susceptible.impact", {
+          ? `${game.i18n.format("arm5e.realm.susceptible.impact", {
               realm: game.i18n.localize(CONFIG.ARM5E.realms[this.magic.realm].label),
               divisor: 2
             })}<br>`
           : "";
-        const totalMagicResistance = `${game.i18n.localize("arm5e.sheet.totalMagicResistance")}: (${
+        const totalMagicResistance = `${game.i18n.localize("arm5e.chat.totalMagicResistance")}: (${
           target.magicResistance.total
         })`;
-        flavorTotalMagicResistance = `${might}${parma}${parmaSpecialty}${form}${aura}<br/>${susceptibility}<b>${totalMagicResistance}</b>`;
+        if (target.magicResistance.otherResistance) {
+          flavorTotalMagicResistance = `${game.i18n.localize(
+            "arm5e.chat.otherMagicResistance"
+          )} : ${
+            target.magicResistance.otherResistance
+          }<br/>${susceptibility}<b>${totalMagicResistance}</b>`;
+        } else {
+          flavorTotalMagicResistance = `${might}${parma}${parmaSpecialty}${form}${aura}<br/>${susceptibility}<b>${totalMagicResistance}</b>`;
+        }
       }
 
       const total =

--- a/module/sheets/active-effect-config-sheet_V2.js
+++ b/module/sheets/active-effect-config-sheet_V2.js
@@ -143,7 +143,7 @@ export class ArM5eActiveEffectConfigV2 extends ActiveEffectConfig {
         }
         subType.computedKey = tmp;
 
-        subType.modeStr = "arm5e.sheet.activeEffect.mode_" + subType.mode;
+        subType.modeStr = "arm5e.activeEffect.mode_" + subType.mode;
 
         subTypes.push(subType);
         if (k == context.selectedSubtypes[idx]) {

--- a/module/tools.js
+++ b/module/tools.js
@@ -597,67 +597,67 @@ export function generateActiveEffectFromAbilities() {
     bonusArcaneAbility: {
       category: "abilities",
       type: "bonusArcaneAbility",
-      label: "arm5e.sheet.activeEffect.types.arcaneAbilitiesBonus",
+      label: "arm5e.activeEffect.types.arcaneAbilitiesBonus",
       subtypes: {}
     },
     bonusAcademicAbility: {
       category: "abilities",
       type: "bonusAcademicAbility",
-      label: "arm5e.sheet.activeEffect.types.academicAbilitiesBonus",
+      label: "arm5e.activeEffect.types.academicAbilitiesBonus",
       subtypes: {}
     },
     bonusMartialAbility: {
       category: "abilities",
       type: "bonusMartialAbility",
-      label: "arm5e.sheet.activeEffect.types.martialAbilitiesBonus",
+      label: "arm5e.activeEffect.types.martialAbilitiesBonus",
       subtypes: {}
     },
     bonusMysteryAbility: {
       category: "abilities",
       type: "bonusMysteryAbility",
-      label: "arm5e.sheet.activeEffect.types.mysteryAbilitiesBonus",
+      label: "arm5e.activeEffect.types.mysteryAbilitiesBonus",
       subtypes: {}
     },
     bonusSupernaturalAbility: {
       category: "abilities",
       type: "bonusSupernaturalAbility",
-      label: "arm5e.sheet.activeEffect.types.supernaturalAbilitiesBonus",
+      label: "arm5e.activeEffect.types.supernaturalAbilitiesBonus",
       subtypes: {}
     },
     affinityGeneralAbility: {
       category: "abilities",
       type: "affinityGeneralAbility",
-      label: "arm5e.sheet.activeEffect.types.generalAbilitiesAffinity",
+      label: "arm5e.activeEffect.types.generalAbilitiesAffinity",
       subtypes: {}
     },
     affinityArcaneAbility: {
       category: "abilities",
       type: "affinityArcaneAbility",
-      label: "arm5e.sheet.activeEffect.types.arcaneAbilitiesAffinity",
+      label: "arm5e.activeEffect.types.arcaneAbilitiesAffinity",
       subtypes: {}
     },
     affinityAcademicAbility: {
       category: "abilities",
       type: "affinityAcademicAbility",
-      label: "arm5e.sheet.activeEffect.types.academicAbilitiesAffinity",
+      label: "arm5e.activeEffect.types.academicAbilitiesAffinity",
       subtypes: {}
     },
     affinityMartialAbility: {
       category: "abilities",
       type: "affinityMartialAbility",
-      label: "arm5e.sheet.activeEffect.types.martialAbilitiesAffinity",
+      label: "arm5e.activeEffect.types.martialAbilitiesAffinity",
       subtypes: {}
     },
     affinityMysteryAbility: {
       category: "abilities",
       type: "affinityMysteryAbility",
-      label: "arm5e.sheet.activeEffect.types.mysteryAbilitiesAffinity",
+      label: "arm5e.activeEffect.types.mysteryAbilitiesAffinity",
       subtypes: {}
     },
     affinitySupernaturalAbility: {
       category: "abilities",
       type: "affinitySupernaturalAbility",
-      label: "arm5e.sheet.activeEffect.types.supernaturalAbilitiesAffinity",
+      label: "arm5e.activeEffect.types.supernaturalAbilitiesAffinity",
       subtypes: {}
     }
   };

--- a/module/tools/labExperimentation.js
+++ b/module/tools/labExperimentation.js
@@ -165,7 +165,12 @@ export class LabExperimentation extends FormApplication {
           reportBody += await this._rollForExperimentation(risk, aura, discovery);
         }
       } else {
-        const tableRef = res.find((e) => e.type == "pack");
+        let tableRef;
+        if (CONFIG.ISV13) {
+          tableRef = res.find((e) => e.type == "document");
+        } else {
+          tableRef = res.find((e) => e.type == "pack");
+        }
         const subRt = docs.find((e) => tableRef.documentId === e._id);
         const subTitle = res.find((e) => e.type == "text").text;
         reportBody += this._getTableResult("extraordinaryResults", subTitle);

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "2.4.0.23",
+  "version": "2.4.0.24",
   "compatibility": {
     "minimum": "12.343",
     "verified": "13.348"

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "2.4.0.24",
+  "version": "2.4.0.25",
   "compatibility": {
     "minimum": "12.343",
     "verified": "13.348"

--- a/templates/actor/actor-beast-sheet.html
+++ b/templates/actor/actor-beast-sheet.html
@@ -22,6 +22,12 @@
                   arm5e.aging.crisis.tooltip"}}'><i class="icon-Icon_Aging_crisis"></i></a>
               </div>
             {{/if}}
+            {{#if system.states.confidencePrompt}}
+              <div class="flex0 padding10" style="width:36px"><a class="clear-confidencePrompt"
+                  title='{{localize "arm5e.sheet.states.confidencePrompt"}}' style="font-size: 20pt;"><i
+                    class="fas fa-user-plus"></i></a>
+              </div>
+            {{/if}}
             {{#if devMode}}
               <div class="flex0 padding10" style="width:24px"><a class="migrate" title="Migrate actor"><i
                     class="fas fa-arrow-up"></i></a></div>

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -25,6 +25,12 @@
                   arm5e.aging.crisis.tooltip"}}'><i class="icon-Icon_Aging_crisis"></i></a>
               </div>
             {{/if}}
+            {{#if system.states.confidencePrompt}}
+              <div class="flex0 padding10" style="width:36px"><a class="clear-confidencePrompt"
+                  title='{{localize "arm5e.sheet.states.confidencePrompt"}}' style="font-size: 20pt;"><i
+                    class="fas fa-user-plus"></i></a>
+              </div>
+            {{/if}}
             {{#if system.twilight.stage}}
               <div class="flex01" style="padding: 5px;">
                 <a class="twilight-episode clickable" data-year="{{datetime.year}}" data-season="{{datetime.season}}"

--- a/templates/actor/parts/actor-abilities.html
+++ b/templates/actor/parts/actor-abilities.html
@@ -24,8 +24,8 @@
         {{#each abilitySet.abilities as |item id|}}
           <li class="item item-value flexrow flex-center macro-ready" data-name="{{item.name}}" data-attribute="{{id}}"
             data-item-id="{{item._id}}">
-            <div class="item-image item-control item-edit"><img src="{{item.img}}" width="45" height="45"
-                title="{{item.name}}" />
+            <div class="item-image item-control item-edit">
+              <img src="{{item.img}}" width="45" height="45" title="{{item.name}}" />
             </div>
             <div class="flexrow flex-center">
               <span class="flexrow item-title rollable width4" data-roll="ability" data-ability="{{item._id}}"

--- a/templates/actor/parts/actor-magicSystem-cfg.html
+++ b/templates/actor/parts/actor-magicSystem-cfg.html
@@ -23,8 +23,7 @@
       <input class="" name="system.magicSystem.laboratory" value="{{system.magicSystem.laboratory}}" type="text" />
     </div>
     <div class="flexrow resource">
-      <label class="header-label"
-        style="padding-top: 4px; padding-left: 24px">{{localize "arm5e.sheet.realm.label"}}</label>
+      <label class="header-label" style="padding-top: 4px; padding-left: 24px">{{localize "arm5e.realm.label"}}</label>
       <select class="change-realm" name="system.magicSystem.realm" value="{{system.magicSystem.realm}}"
         data-type="String">
         {{selectOptions config.realmsExt selected=system.magicSystem.realm labelAttr="label" localize=true}}

--- a/templates/actor/parts/actor-magicSystem.html
+++ b/templates/actor/parts/actor-magicSystem.html
@@ -1,4 +1,4 @@
-{{log "magicSystem templates" system.magicSystem.templates }}
+{{!-- log "magicSystem templates" system.magicSystem.templates --}}
 {{#each system.magicSystem.templates as |template tid|}}
   <div class="flexrow backSection margintop18">
     <ol class="items-list">
@@ -15,7 +15,7 @@
       </li>
       {{> "systems/arm5e/templates/generic/metalic-bar.html" }}
       {{#each (lookup ../system.supernaturalEffectsTemplates tid) as |item id|}}
-        {{log "template "  @root.system.magicSystem.templates tid }}
+        {{!--log "template "  @root.system.magicSystem.templates tid --}}
         <li class="item item-value flexrow macro-ready" data-name="{{item.name}}" data-item-id="{{item._id}}">
 
           <div class="item-image item-control item-edit"><img src="{{item.img}}" title="{{item.name}}" /></div>

--- a/templates/actor/parts/actor-soak.html
+++ b/templates/actor/parts/actor-soak.html
@@ -32,7 +32,6 @@
       </div>
       <div class="flexrow flex-group-center">
         <label class="header-label">{{localize "arm5e.sheet.formRes"}}</label>
-        {{log this}}
         <select name="formRes" data-type="String">
           {{selectOptions selection.formRes selected=formRes nameAttr="res" valueAttr="res" labelAttr="label" blank="" }}
         </select>

--- a/templates/actor/parts/actor-virtuesFlaws.html
+++ b/templates/actor/parts/actor-virtuesFlaws.html
@@ -24,7 +24,9 @@
       {{#each system.virtues as |item id|}}
         {{#if item.system.visible }}
           <li class="item item-value flexrow" data-name="{{item.name}}" data-item-id="{{item._id}}">
-            <div class="item-image item-control item-edit"><img src="{{item.img}}" title="{{item.name}}" /></div>
+            <div class="item-image item-control item-edit">
+              <img src="{{item.img}}" width="45" height="45" title="{{item.name}}" />
+            </div>
             <div class="flexrow flex-center">
               <span class="flexrow item-title" {{{item.system.ui.style}}}>{{item.name}}</span>
             </div>
@@ -61,7 +63,9 @@
         {{#each system.qualities as |item id|}}
           {{#if item.system.visible }}
             <li class="item item-value flexrow" data-name="{{item.name}}" data-item-id="{{item._id}}">
-              <div class="item-image item-control item-edit"><img src="{{item.img}}" title="{{item.name}}" /></div>
+              <div class="item-image item-control item-edit">
+                <img src="{{item.img}}" width="45" height="45" title="{{item.name}}" />
+              </div>
               <div class="flexrow flex-center">
                 <span class="flexrow item-title" {{{item.system.ui.style}}}>{{item.name}}</span>
               </div>
@@ -104,7 +108,9 @@
       {{#each system.flaws as |item id|}}
         {{#if item.system.visible }}
           <li class="item item-value flexrow" data-name="{{item.name}}" data-item-id="{{item._id}}">
-            <div class="item-image item-control item-edit"><img src="{{item.img}}" title="{{item.name}}" /></div>
+            <div class="item-image item-control item-edit">
+              <img src="{{item.img}}" width="45" height="45" title="{{item.name}}" />
+            </div>
             <div class="flexrow flex-center">
               <span class="flexrow item-title" {{{item.system.ui.style}}}>{{item.name}} </span>
             </div>
@@ -144,7 +150,9 @@
         {{#each system.inferiorities as |item id|}}
           {{#if item.system.visible }}
             <li class="item item-value flexrow" data-name="{{item.name}}" data-item-id="{{item._id}}">
-              <div class="item-image item-control item-edit"><img src="{{item.img}}" title="{{item.name}}" /></div>
+              <div class="item-image item-control item-edit">
+                <img src="{{item.img}}" width="45" height="45" title="{{item.name}}" />
+              </div>
               <div class="flexrow flex-center">
                 <span class="flexrow item-title" {{{item.system.ui.style}}}>{{item.name}} </span>
               </div>

--- a/templates/actor/parts/template-item-ability.hbs
+++ b/templates/actor/parts/template-item-ability.hbs
@@ -7,7 +7,6 @@
       data-id="{{id}}"
       data-index="{{compIdx}}"
     >
-      {{!-- {{log "this.selection: " this.extendedKey}} --}}
       {{selectOptions
         this.selection
         selected=this.extendedKey

--- a/templates/generic/active-effect-config.html
+++ b/templates/generic/active-effect-config.html
@@ -60,8 +60,8 @@
       <header class="effect-change effects-header flexrow">
         <div class="type">{{ localize "arm5e.sheet.type" }}</div>
         <div class="key">{{ localize "arm5e.sheet.attributes" }}</div>
-        <div class="mode">{{ localize "arm5e.sheet.activeEffect.changeMode" }}</div>
-        <div class="value">{{ localize "arm5e.sheet.activeEffect.changeValue" }}</div>
+        <div class="mode">{{ localize "arm5e.activeEffect.changeMode" }}</div>
+        <div class="value">{{ localize "arm5e.activeEffect.changeValue" }}</div>
         <div class="effect-controls">
           <a class="effect-control" data-action="add"><i class="fas fa-plus"></i></a>
         </div>

--- a/templates/generic/active-effects.html
+++ b/templates/generic/active-effects.html
@@ -48,7 +48,7 @@
     </ol>
   {{/each}} {{#unless system.effectCreation}}
     <li class="items-header flexrow" data-effect-type="{{section.type}}" style="text-align: center">
-      {{localize "arm5e.sheet.activeEffect.info.noedit"}}
+      {{localize "arm5e.activeEffect.info.noedit"}}
     </li>
   {{/unless}}
 </ol>

--- a/templates/generic/aura-config.html
+++ b/templates/generic/aura-config.html
@@ -2,24 +2,24 @@
   {{> "systems/arm5e/templates/roll/parts/roll-header.html" header="Inputs" }}
   <div class="marginsides32">
     <div class="form-group">
-      <label>{{localize "arm5e.sheet.realm.visible"}} <i class="fa-regular fa-circle-question"
+      <label>{{localize "arm5e.realm.visible"}} <i class="fa-regular fa-circle-question"
           data-tooltip="{{localize 'arm5e.sheet.realm.visibleHint'}}"></i></label>
       <input type="checkbox" name="visible" {{checked aura.visible}} />
     </div>
 
     {{#each aura.values}}
       <div class="form-group">
-        <label>{{localize (concat "arm5e.sheet.realm." @key)}}</label>
+        <label>{{localize (concat "arm5e.realm." @key)}}</label>
         <input type="number" name="{{@key}}" value="{{this}}" />
       </div>
     {{/each}}
 
     <fieldset>
-      <legend>{{localize "arm5e.sheet.realm.nightModifier"}}</legend>
+      <legend>{{localize "arm5e.realm.nightModifier"}}</legend>
 
       {{#each aura.nightModifier}}
         <div class="form-group">
-          <label>{{localize (concat "arm5e.sheet.realm." @key)}}</label>
+          <label>{{localize (concat "arm5e.realm." @key)}}</label>
           <input type="number" name="{{@key}}NightModifier" value="{{this}}" />
         </div>
       {{/each}}

--- a/templates/item/item-ability-sheet.html
+++ b/templates/item/item-ability-sheet.html
@@ -59,7 +59,7 @@
         {{/unless}}
         {{#if (eq system.category "supernaturalCat") }}
           <div class="flexcol " style="padding-left:5px">
-            <label class>{{localize "arm5e.sheet.realm.label"}}</label>
+            <label class>{{localize "arm5e.realm.label"}}</label>
             <select name="system.realm" data-type="String">
               {{selectOptions config.realmsExt selected=system.realm labelAttr="label" localize=true }}
             </select>

--- a/templates/item/item-power-sheet.html
+++ b/templates/item/item-power-sheet.html
@@ -23,7 +23,7 @@
       {{#unless ownerHasMight}}
         <div class="resource flexrow">
           <div class="resource flexcol">
-            <label for="system.cost" class="header-label">{{localize "arm5e.sheet.realm.label"}}</label>
+            <label for="system.cost" class="header-label">{{localize "arm5e.realm.label"}}</label>
             <select name="system.realm" data-type="String">
               {{selectOptions config.realmsExt selected=system.realm labelAttr="label" localize=true }}
             </select>

--- a/templates/item/item-virtue-sheet.html
+++ b/templates/item/item-virtue-sheet.html
@@ -11,7 +11,6 @@
               {{selectOptions config.virtueFlawTypes.available selected=system.type labelAttr="label" localize=true }}
             </select>
           </div>
-          {{log "TOTO toto"}}
           <div class="resource">
             <label for="system.impact.value" class="header-label">{{localize system.impact.label}}</label>
             <select name="system.impact.value" data-type="String">
@@ -33,7 +32,6 @@
       </div>
     </div>
   </header>
-  {{log "TOTO tabs"}}
   {{!-- Sheet Tab Navigation --}}
   <nav class="arm5eTabs sheet-tabs tabs" data-group="primary">
     <a class="item posRelative" data-tab="description">

--- a/templates/item/parts/activities.html
+++ b/templates/item/parts/activities.html
@@ -161,7 +161,6 @@
               class="progress-art flex02" {{@root.system.disabled}} style="min-width: 150px;">
               {{selectOptions @root.system.ownedArts selected=art.key labelAttr="label" nameAttr="key" valueAttr="key"}}
             </select>
-            {{log "TOTO02"}}
             <div class="xp">
               {{#unless ../ui.showTeacher}}
                 <input type="number" name="system.progress.arts.{{idx}}.xp" value="{{art.xp}}" data-dtype="Number"

--- a/templates/lab-activities/longevity-ritual.html
+++ b/templates/lab-activities/longevity-ritual.html
@@ -19,7 +19,7 @@
               value="{{planning.data.subject.name}}" data-dtype="String" />
           </div>
           <div class="flexcol">
-            <label class="header-label ">{{localize "arm5e.sheet.realm.magic"}}</label>
+            <label class="header-label ">{{localize "arm5e.realm.magic"}}</label>
             <input type="checkbox" {{ui.subjectMagical}} name="{{planning.namePrefix}}subject.magical" {{checked
               planning.data.subject.magical}} data-dtype="Boolean" />
           </div>

--- a/templates/roll/roll-characteristic.html
+++ b/templates/roll/roll-characteristic.html
@@ -42,7 +42,6 @@
       <label class="resource-label">{{localize "arm5e.sheet.wounds"}} ({{ system.penalties.wounds.total }})</label>
     </div>
     <div class="flex-group-center">
-      {{log this}}
       <img src="systems/arm5e/assets/ballSilver.png" width="20" height="20" style="border :0px" />
       <div class="flex-group-center flexrow" style="margin-top: 10px;">
         <label class="resource-label flex03">{{localize "arm5e.generic.difficulty" }}</label>

--- a/templates/roll/roll-twilightStrength.html
+++ b/templates/roll/roll-twilightStrength.html
@@ -14,15 +14,16 @@
     </div>
     <div class="flexrow flex-group-center">
       <label class="resource-label flex03">{{localize "arm5e.sheet.modifier"}}</label>
-      <input type="Number" name="system.roll.modifier" value="{{system.roll.modifier}}" data-dtype="Number"
+      <input type="number" name="system.roll.modifier" value="{{system.roll.modifier}}" data-dtype="Number"
         class="SelectedModifier resource-focus" />
     </div>
     <div class="flexrow flex-group-center">
       <label class="resource-label">+</label>
     </div>
     <div class="flexrow flex-group-center">
-      <label class="resource-label">{{ lookup system.roll.generic.txtOption 1 }} ({{lookup system.roll.generic.option 1
-        }})</label>
+      <label class="resource-label flex03">{{localize "arm5e.twilight.warpingPoints"}}</label>
+      <input type="number" name="system.roll.twilight.warpingPts" value="{{system.roll.twilight.warpingPts}}"
+        data-dtype="Number" class="SelectedWarpingPoints resource-focus" />
     </div>
     {{#if system.roll.twilight.enigma.score}}
       <div class="flexrow flex-group-center">

--- a/templates/roll/roll-twilightUnderstanding.html
+++ b/templates/roll/roll-twilightUnderstanding.html
@@ -25,10 +25,10 @@
           </div>
         {{/if}}
       </div>
+      <div class="flexrow flex-group-center">
+        <label class="resource-label">+</label>
+      </div>
     {{/if}}
-    <div class="flexrow flex-group-center">
-      <label class="resource-label">+</label>
-    </div>
     <div class="flexrow flex-group-center">
       <label class="resource-label flex03">{{localize "arm5e.sheet.modifier"}}</label>
       <input type="Number" name="system.roll.modifier" value="{{system.roll.modifier}}" data-dtype="Number"

--- a/templates/sheets/active-effect/changes.hbs
+++ b/templates/sheets/active-effect/changes.hbs
@@ -5,8 +5,8 @@
       <header class="effect-change effects-header flexrow">
         <div class="type">{{ localize "arm5e.sheet.type" }}</div>
         <div class="key">{{ localize "arm5e.sheet.attributes" }}</div>
-        <div class="mode">{{ localize "arm5e.sheet.activeEffect.changeMode" }}</div>
-        <div class="value">{{ localize "arm5e.sheet.activeEffect.changeValue" }}</div>
+        <div class="mode">{{ localize "arm5e.activeEffect.changeMode" }}</div>
+        <div class="value">{{ localize "arm5e.activeEffect.changeValue" }}</div>
         <div class="effect-controls">
           <a class="addChange" data-action="add"><i class="fas fa-plus"></i></a>
         </div>

--- a/templates/sheets/active-effect/header.hbs
+++ b/templates/sheets/active-effect/header.hbs
@@ -1,5 +1,4 @@
 <header class="sheet-header effect-options flexrow">
-  {{log "header" this}}
   {{!> "systems/arm5e/templates/generic/largeDialog-header.hbs" header="Inputs" }}
   <img class="item-small-img" src="{{data.ui.img}}" />
   <h1 class="effect-title">{{data.ui.name}}</h1>

--- a/tools/flattenLangFiles.cjs
+++ b/tools/flattenLangFiles.cjs
@@ -1,11 +1,21 @@
 const fs = require("fs");
 const path = require("path");
 
-/**
- * Recursively sorts all properties of a JSON object alphabetically.
- * @param {any} obj
- * @returns {any}
- */
+function flattenObject(obj, prefix = "", res = {}) {
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        flattenObject(value, newKey, res);
+      } else {
+        res[newKey] = value;
+      }
+    }
+  }
+  return res;
+}
+
 function sortProperties(obj) {
   if (Array.isArray(obj)) {
     return obj.map(sortProperties);
@@ -20,31 +30,6 @@ function sortProperties(obj) {
     return obj;
   }
 }
-
-/**
- * Expands a flat JSON object with dot-separated keys into a nested object.
- * @param {Object} flatObj
- * @returns {Object}
- */
-function expandFlatJSON(flatObj) {
-  const result = {};
-  for (const key in flatObj) {
-    const parts = key.split(".");
-    let current = result;
-    for (let i = 0; i < parts.length; i++) {
-      if (i === parts.length - 1) {
-        current[parts[i]] = flatObj[key];
-      } else {
-        if (!current[parts[i]] || typeof current[parts[i]] !== "object") {
-          current[parts[i]] = {};
-        }
-        current = current[parts[i]];
-      }
-    }
-  }
-  return result;
-}
-
 // Get language argument from command line
 const lang = process.argv[2] || "all";
 
@@ -63,7 +48,7 @@ if (lang === "all") {
 
     // Read, flatten, sort, and write
     const json = JSON.parse(fs.readFileSync(filePath, "utf8"));
-    const flatten = expandFlatJSON(json);
+    const flatten = flattenObject(json);
     const sorted = sortProperties(flatten);
 
     fs.writeFileSync(filePath, JSON.stringify(sorted, null, 2), "utf8");


### PR DESCRIPTION
## 2.4.0.25, Radislav agrees with Quendalon

### V13 compatibility

### Features & changes

- Various improvements to chat messages design.
- New active effects:
  - Alternate Arts XP bonus
  - Specific form magic resistance (not cumulative with Parma)
- [Technical] Mnemonics reorganization - WIP

## Bug fixes

- Parma is now properly multiplied by 5 when computing magic resistance during contest.
- It is now possible to edit the number of warping points when triggering a Twilight manually
- Confidence spending was not allowed for Twilight control and understanding.
- Virtues and flaws icons were reduced to size 0