### PR TITLE
bug fix + updated translations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-## 3.0.0.7 Stentorius
+## 3.0.0.8 Stentorius
 
 ### Compatibility
 
@@ -37,6 +37,15 @@
 - New dialog to pick any kind of documents from a filtered list.
   - Available for macros
   - Replace the drag and drop zones for non-GM users
+- New active effects
+  - Vis extraction activity modifier
+  - Enchanting activity modifier
+  - Item investigation modifier
+  - Longevity Rituals modifier
+- It will be possible for players to disable creation mode by clicking on the icon
+- Updated translations:
+  - French by @Orneen
+  - Brazilian Portuguese by @Gapherd
 
 ### Bug fixes
 
@@ -60,6 +69,7 @@
   - Dropping an empty book no longer raises an error and close the Scriptorium
   - When the writer has no qualifying abilities, warnings were pushed to the reading tab so the Writing tab never showed an error.
   - Copying Ability summae takes now the proper time.
+  - Maximum level is not computed properly with Tractati in the Scriptorium
 
 ## 2.4.1.14, Radislav, Cognizant Wisdom BF1
 

--- a/css/arm5e.css
+++ b/css/arm5e.css
@@ -168,6 +168,9 @@
   --font-size-10: 10pt;
   --font-size-12: 12pt;
   --font-size-14: 14pt;
+  --font-size-16: 16pt;
+  --font-size-20: 20pt;
+  --font-size-32: 32pt;
   --z-index-tooltip: 9999;
 }
 
@@ -540,7 +543,7 @@ h3.dice-msg {
 
 .arm5e .sanatorium .progressbar-inner {
   height: 100%;
-  background-color: var(--accent-conflict);
+  background-color: var(--arm5e-c-conflict);
   background-size: 18px 18px;
   box-shadow: inset 0 2px 8px rgba(255, 255, 255, 0.5), inset -1px -1px 0 rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-small);
@@ -666,37 +669,6 @@ input:disabled:hover {
   background-color: rgb(218, 216, 204);
 }
 
-/* Range styling grouped */
-.arm5e input[type="range"] {
-  -webkit-appearance: none;
-  appearance: none;
-  background: transparent;
-  cursor: pointer;
-}
-.arm5e input[type="range"]::-webkit-slider-runnable-track,
-.arm5e input[type="range"]::-moz-range-track {
-  background: rgba(194, 183, 154, 0.8);
-  height: 0.5rem;
-}
-.arm5e input[type="range"]::-webkit-slider-thumb,
-.arm5e input[type="range"]::-moz-range-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  border: none;
-  border-radius: var(--radius-lg);
-  outline: transparent;
-  height: 20px;
-  width: 20px;
-  background-color: transparent;
-}
-.arm5e input[type="range"]::-webkit-slider-thumb {
-  margin-top: -8px;
-  background-image: url("../assets/ballSilver.png");
-}
-.arm5e input[type="range"]::-moz-range-thumb {
-  background-image: url("../assets/ballBronze.png");
-}
-
 /* Checkbox unified */
 input[type="color"] {
   width: 32px;
@@ -730,17 +702,19 @@ input[type="checkbox"]::before {
   background-color: rgb(112, 15, 15);
   flex-shrink: 0;
 }
+/* ::after overrides Foundry core's :checked::after which renders an orange/amber square */
 input[type="checkbox"]::after {
   content: "";
   width: 20px;
   height: 20px;
-  /* padding: 1px; */
   clip-path: polygon(0 20%, 0 60%, 29% 100%, 100% 29%, 100% 1%, 35% 61%);
   transform: scale(0);
   background-color: rgb(112, 15, 15);
   color: var(--arm5e-c-black);
 }
-
+input[type="checkbox"]:checked::after {
+  transform: scale(0); /* keep Foundry's orange square invisible; ::before handles the checkmark */
+}
 input[type="checkbox"].crossed::before {
   clip-path: polygon(
     11% 6%,
@@ -984,7 +958,7 @@ input[type="checkbox"].tiny-checkbox:checked::before {
   min-width: 160px;
   padding: 6px 8px;
   background: rgba(188, 179, 155, 0.9);
-  font-family: var(--font-book) Bold;
+  font-family: var(--font-book-bold);
   font-size: var(--font-size-14);
   line-height: var(--font-size-16);
   color: rgb(0 0 0 / 90%);
@@ -1034,30 +1008,28 @@ body .locked-tooltip.active {
 }
 
 /* Keep component-specific backgrounds (reduced duplication) */
-.arm5e .mainPlayer {
-  background-image: url("../assets/PC/background.webp");
+.arm5e .mainPlayer,
+.arm5e .mainNPC,
+.arm5e .mainLaboratory,
+.arm5e .mainCodex,
+.arm5e .mainCovenant {
   background-repeat: repeat-y;
   background-size: contain;
+}
+.arm5e .mainPlayer {
+  background-image: url("../assets/PC/background.webp");
 }
 .arm5e .mainNPC {
   background-image: url("../assets/NPC/background.webp");
-  background-repeat: repeat-y;
-  background-size: contain;
 }
 .arm5e .mainLaboratory {
   background-image: url("../assets/Lab/background.webp");
-  background-repeat: repeat-y;
-  background-size: contain;
 }
 .arm5e .mainCodex {
   background-image: url("../assets/codex/background.webp");
-  background-repeat: repeat-y;
-  background-size: contain;
 }
 .arm5e .mainCovenant {
   background-image: url("../assets/covenant/background.webp");
-  background-repeat: repeat-y;
-  background-size: contain;
 }
 
 /* Component-specific exceptions retained where required by layout */
@@ -1081,12 +1053,7 @@ body .locked-tooltip.active {
   font-size: 14pt;
   justify-content: center;
 }
-.arm5eTabs,
-.arm5eSubTabs {
-  border: 0 !important; /* Override Foundry core tab border */
-  /* min-height: 36px; */
-  /* margin-bottom: 12px !important; */
-}
+/* .arm5eTabs and .arm5eSubTabs are fully defined below with complete properties */
 
 .arm5e nav.tabs {
   align-items: center;
@@ -1233,14 +1200,23 @@ a.header-button.close {
   background: rgba(100, 80, 20, 0.18);
 }
 
-.arm5e .sanatorium-title,
-.arm5e .medhistory-title {
+.arm5e .sanatorium-title {
   text-align: center;
   font-family: var(--font-header);
   font-size: 32pt;
   height: 35px;
+  border: none;
   margin-left: -64px;
-  color: var(--accent-conflict);
+  color: var(--arm5e-c-conflict);
+}
+.arm5e .medhistory-title {
+  text-align: center;
+  font-family: var(--font-header);
+  font-size: 24pt;
+  height: 35px;
+  border: none;
+  margin-left: -64px;
+  color: var(--arm5e-c-conflict);
 }
 
 /* small utility classes preserved */
@@ -1503,7 +1479,6 @@ a.content-link,
   word-break: break-all;
   text-decoration: underline;
   color: #6e98db;
-  border-bottom: 1px dotted blue;
   border: none;
   background-color: transparent;
   background-image: none;
@@ -1512,15 +1487,6 @@ a.content-link,
 
 .arm5e a.content-link.broken,
 .arm5e .journal-entry-page a.content-link.broken {
-  border-radius: var(--radius-xs);
-  white-space: nowrap;
-  word-break: break-all;
-  text-decoration: underline;
-  border-bottom: 1px dotted blue;
-  border: none;
-  background-color: transparent;
-  background-image: none;
-  padding: 0px;
   color: #f05959;
 }
 
@@ -1720,7 +1686,7 @@ h4.window-title {
 .arm5e .sanatorium .editor {
   overflow-y: auto;
   max-height: 300px;
-  font-family: "var(--font-book)";
+  font-family: var(--font-book);
 }
 
 .arm5e .wound .sheet-body .editor {
@@ -1734,7 +1700,6 @@ h4.window-title {
 }
 
 .arm5e.button.ui {
-  font-family: var(--font-header);
   padding: 5px;
 }
 
@@ -1768,7 +1733,7 @@ button.template-item {
 
 /* Removed duplicate chat-message styling; canonical definition above uses CSS variables */
 .system-arm5e .dice-msg {
-  font-family: bookAntika;
+  font-family: var(--font-book);
   border-bottom: 0px;
   text-align: center;
 }
@@ -1792,7 +1757,7 @@ p,
 .chat-message .message-header,
 .chat-message .message-content {
   user-select: text;
-  font-family: "var(--font-book)";
+  font-family: var(--font-book);
   font-size: var(--font-size-12);
 }
 
@@ -1859,7 +1824,7 @@ p,
   background-image: url("../assets/background.webp");
   background-repeat: repeat-y;
   background-size: 100%;
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
   padding: 32px;
 }
 
@@ -1867,7 +1832,7 @@ p,
   background-image: var(--dialog-bg);
   background-repeat: repeat-y;
   background-size: cover;
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
   font-size: 12pt;
   width: 100%;
   height: 100%;
@@ -1892,16 +1857,6 @@ p,
   padding: 5px;
   /* padding-top: 20px;
   padding-bottom: 0px; */
-}
-
-.calendar-sheet .schedule-years {
-  height: 424px;
-  overflow-y: scroll;
-}
-
-.calendar-sheet .calendar-years {
-  height: 300px;
-  overflow-y: scroll;
 }
 
 /* .calendar-season {
@@ -2002,62 +1957,12 @@ p,
   position: relative;
 }
 
-.arm5e .sanatorium-title {
-  text-align: center;
-  font-family: var(--font-header);
-  font-size: 32pt;
-  height: 35px;
-  border: none;
-  margin-left: -64px;
-  color: rgb(135 38 22 / 100%);
-}
-
 .item-summary {
-  font-family: "var(--font-book)";
+  font-family: var(--font-book);
   padding: 6px;
   border-bottom: solid;
   border-bottom-color: #bebcb8;
   border-bottom-width: 1px;
-}
-.arm5e .sanatorium .progressbar {
-  width: 400px;
-  height: 16px;
-  margin: 0 auto 10px auto;
-  padding: 0px;
-  background-image: url("../assets/SmallGoldenEngravedBar.png");
-  background-size: 400px 16px;
-  /* background: #cfcfcf; */
-  border-width: 1px;
-  border-style: solid;
-  border-color: #aaa #bbb #fff #bbb;
-  box-shadow: inset 0px 2px 3px #bbb;
-}
-
-.arm5e .sanatorium .progressbar,
-.arm5e .sanatorium .progressbar-inner {
-  border-radius: var(--radius-small);
-}
-.arm5e .sanatorium .progressbar-inner {
-  height: 100%;
-  background: #999 80%;
-  background-size: 18px 18px;
-  background-color: rgb(135 38 22 / 100%);
-  box-shadow: inset 0px 2px 8px rgba(255, 255, 255, 0.5), inset -1px -1px 0px rgba(0, 0, 0, 0.2);
-}
-
-.arm5e .sanatorium .progressbar-red .progressbar-inner {
-  background-color: #f67;
-  width: 30%;
-}
-
-.arm5e .medhistory-title {
-  text-align: center;
-  font-family: var(--font-header);
-  font-size: 24pt;
-  height: 35px;
-  border: none;
-  margin-left: -64px;
-  color: rgb(135 38 22 / 100%);
 }
 
 /* ============================================
@@ -2120,7 +2025,7 @@ p,
   background-repeat: repeat-y;
   background-size: cover;
   background-color: var(--arm5e-c-tan);
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
   width: 397px;
   height: auto;
 }
@@ -2158,11 +2063,11 @@ p,
   background-image: var(--dialog-bg-large);
   background-repeat: repeat-y;
   background-size: cover;
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
 }
 
 .arm5eActiveEffect .effect-options {
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
   padding-left: 48px;
   padding-right: 48px;
   height: auto;
@@ -2189,7 +2094,7 @@ p,
 }*/
 
 .arm5e-roll .roll-options {
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
   padding-left: 32px;
   padding-right: 32px;
   background-size: cover;
@@ -2267,33 +2172,6 @@ p,
   border-right: 1px solid #7a7971;
 } */
 
-.arm5e .sanatorium input[type="number"],
-.arm5e .sanatorium input[type="text"],
-.arm5e .calendar input[type="number"],
-.arm5e .calendar input[type="text"],
-.arm5e .astrolab input[type="text"],
-.arm5e .astrolab input[type="number"] {
-  font-family: "var(--font-book)";
-  font-weight: bold;
-  background: var(--arm5e-c-shadow);
-  height: 25px;
-  background-image: none;
-}
-
-.arm5e .scriptorium input[type="text"],
-.arm5e .scriptorium input[type="number"] {
-  font-family: "var(--font-book)";
-  font-weight: normal;
-  height: 13pt;
-  background-image: none;
-  max-width: 190px;
-}
-
-/* input[type="number"].select-on-focus {
-  max-width: 70px;
-  text-align: center;
-} */
-
 input[type="text"].slim,
 input[type="number"].slim {
   max-width: 50px;
@@ -2333,31 +2211,10 @@ input[type="number"].design-level {
   box-shadow: var(--shadow-card);
 }
 
-/* Redundant generic select block removed; handled by consolidated base block */
-.arm5e .scriptorium select {
-  font-family: "var(--font-book)";
-  max-width: 220px;
-}
-.arm5e .sanatorium select,
-.arm5e .astrolab select {
-  font-weight: bold;
-  background: var(--arm5e-c-shadow);
-  height: 25px;
-  font-family: "var(--font-book)";
-}
+/* Removed duplicate input/select and sheet-content blocks; canonical definitions above apply */
 
-.arm5e .sheet-content {
-  padding-left: 32px;
-  padding-right: 32px;
-  font-family: "var(--font-book-bold)";
-  font-size: 9pt;
-}
-.arm5e .editor-content {
-  font-family: "var(--font-book)";
-  /* height: fit-content; */
-}
+/* Preserve unique editor-container height rule */
 .arm5e .editor-container .editor-content {
-  /* font-family: "var(--font-book)"; */
   height: fit-content;
 }
 
@@ -2366,7 +2223,7 @@ input[type="number"].design-level {
 .arm5e .mainItem {
   background-repeat: repeat-y;
   background-size: contain;
-  font-family: "var(--font-book-bold)";
+  font-family: var(--font-book-bold);
 }
 
 .arm5e .mainItem .header-background {
@@ -2598,15 +2455,7 @@ img.tinyimg {
   padding: 10px;
 }
 
-fielgr .arm5e .sheet-header h2.covenantname input {
-  width: 100%;
-  margin: 0;
-  /* padding-top: 25px; */
-  line-height: 30px;
-  font-family: var(--font-header);
-  font-weight: 300;
-  /*letter-spacing: 1px;*/
-}
+/* fielgr selector was a typo (non-existent element) — rule removed */
 
 .arm5e .sheet-header h2.codexname {
   padding: 0px;
@@ -2624,7 +2473,7 @@ fielgr .arm5e .sheet-header h2.covenantname input {
 }
 
 .arm5e .diary-tabs {
-  font-family: "var(--font-book)";
+  font-family: var(--font-book);
   font-size: 10pt;
   text-align: center;
   /* background-image: url("../assets/player/bar.webp"); */
@@ -2686,12 +2535,13 @@ fielgr .arm5e .sheet-header h2.covenantname input {
   max-width: 30px;
 }
 
-.section-title {
+.section-title,
+.techLabel,
+.formLabel {
   font-family: var(--font-header);
   font-size: 14pt;
   font-weight: normal;
   align-items: center;
-  /* padding-top: 5px; */
 }
 
 /* Removed duplicate toggle/collapse animation blocks; consolidated canonical definitions above apply */
@@ -2929,18 +2779,12 @@ label.uppercase {
 }
 
 .techLabel {
-  font-family: var(--font-header);
-  font-size: 14pt;
-  font-weight: normal;
-  align-items: center;
+  /* See grouped rule above with .section-title and .formLabel */
   padding-top: 5px;
 }
 
 .formLabel {
-  font-family: var(--font-header);
-  font-size: 14pt;
-  font-weight: normal;
-  align-items: center;
+  /* inherits all base properties from grouped rule above */
 }
 .arm5eTabsPC {
   background-image: url("../assets/PC/bar.webp");
@@ -3306,10 +3150,7 @@ img.art-icon {
 /* Removed duplicate padding/margin utility classes; canonical definitions above apply */
 
 .arm5e .padding12x5 {
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 5px;
-  padding-left: 5px;
+  padding: 5px 12px;
 }
 
 .arm5e-roll .modifier,
@@ -3319,9 +3160,7 @@ img.art-icon {
   text-align: center;
 }
 
-.padding2 {
-  padding: 2px;
-}
+/* .padding2 duplicate removed; see utilities section above */
 
 .arm5e .marginbot12 {
   margin-bottom: 12px;
@@ -3386,7 +3225,7 @@ img.art-icon {
 /* Removed duplicate covenant-tooltip styling; consolidated canonical definition above applies */
 
 body h3.covenant-tooltip {
-  font-family: var(--font-book) Bold;
+  font-family: var(--font-book-bold);
   font-size: 15px;
   color: var(--arm5e-c-black);
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -123,9 +123,9 @@
         "xpmod": "Xp bonus"
       },
       "type": {
-        "covenantModifiers": "Covenant's modifiers",
         "covenantBuildPoint": "Covenant's build points",
         "covenantInhabitants": "Covenant's inhabitants",
+        "covenantModifiers": "Covenant's modifiers",
         "spellcasting": "Spellcasting",
         "yearlyExpenses": "Covenant's expenses",
         "yearlySavings": {
@@ -418,6 +418,12 @@
         "standard": "Standard",
         "standardPlus": "Standard + one expensive piece"
       },
+      "inhabitantsMod": {
+        "laborers": "Magic Laborers",
+        "servants": "Magic Servants",
+        "teamsters": "Magic Teamsters",
+        "turbula": "Magic Turbula"
+      },
       "specialist": {
         "books": "Books related profession",
         "chamberlain": "Chamberlain",
@@ -433,12 +439,6 @@
         "none": "No salary",
         "normal": "Standard salary",
         "pension": "Pension"
-      },
-      "inhabitantsMod": {
-        "laborers": "Magic Laborers",
-        "turbula": "Magic Turbula",
-        "servants": "Magic Servants",
-        "teamsters": "Magic Teamsters"
       }
     },
     "damage": {
@@ -472,10 +472,6 @@
         "yes": "Yes"
       },
       "chooseCovenant": "Choose a covenant",
-      "noDocuments": "No documents found.",
-      "pickActors": "Pick Actors",
-      "pickDocuments": "Pick Documents",
-      "pickItems": "Pick Items",
       "combatDamage": "Combat damage",
       "confirmClearAura": "Are you sure you wish to clear the aura from this scene?",
       "confirmTransfer-amount": "Which quantity do you want to transfer? (Max {max})",
@@ -492,6 +488,10 @@
         "abilityOption": "Only alphanumeric characters."
       },
       "magicItemUse": "Use magic item",
+      "noDocuments": "No documents found.",
+      "pickActors": "Pick Actors",
+      "pickDocuments": "Pick Documents",
+      "pickItems": "Pick Items",
       "powerUse": "Use power",
       "roll": {
         "exploding": {
@@ -564,10 +564,10 @@
       "locked": "Locked",
       "minutes": "minutes",
       "minutesShort": "min.",
+      "misc": "Miscellaneous",
+      "missed": "Missed",
       "modifier": "Modifier",
       "modifiers": "Modifiers",
-      "missed": "Missed",
-      "misc": "Miscellaneous",
       "multiplier": "Multiplier",
       "multipliers": "Multipliers",
       "na": "N/A",
@@ -613,6 +613,7 @@
     "lab": {
       "activity": {
         "chargedEnchantment": "Charged item",
+        "enchanting": "Enchanting",
         "inventSpell": "Invent spell",
         "itemInvestigation": "Item investigation",
         "label": "Laboratory activity",
@@ -1057,11 +1058,8 @@
         "recovery": "Roll for recovery",
         "rollSingle": "Roll wound recovery"
       },
-      "woundRecovery": "Wound recovery",
-      "woundsRecovery": "Wounds recovery",
-      "overstrain": "Overstrain check",
-      "daysAvailbable": "Days available",
       "dayOfSeason": "Season day",
+      "daysAvailbable": "Days available",
       "daysLeft": "{days} days left on next recovery roll",
       "labHealth": "Sanctum help",
       "log": "Patient's file",
@@ -1070,6 +1068,7 @@
       "msg": {
         "clearHistory": "Clear medical history",
         "incapDeath": "The patient dies! (incapacitating wound check botched)",
+        "incapMustBeFirst": "Incapacitating wounds must be treated before lighter wounds can be rolled individually.",
         "logDay": "Recovery period, day {day}",
         "logDone": "Nothing else can be done this season.",
         "logHealed": "Wound completly healed in {days} days",
@@ -1078,38 +1077,39 @@
         "logWoundBetter": "Wound improvement in {days} days",
         "logWoundStable": "Wound stabilized",
         "logWoundWorse": "Wound gets worse in {days} days",
+        "nextSeason": "Advancing to {season} {year}.",
         "noWoundsForOverstrain": "No active wounds to apply an overstrain check.",
         "notOpen": "Open the Sanatorium window first, then roll from here.",
-        "incapMustBeFirst": "Incapacitating wounds must be treated before lighter wounds can be rolled individually.",
-        "nextSeason": "Advancing to {season} {year}.",
         "overstrainNote": "Worsened by overstrain in {season} {year}.",
         "overstrainStable": "Wound holds — no worsening from overstraining.",
         "overstrainWorsened": "{name} worsened to {type} due to overstraining!",
-        "sunriseRoll": "Sunrise",
-        "sunsetRoll": "Sunset",
         "patientDead": "The patient is dead!",
         "patientDied": "The patient died!",
         "patientHealthy": "The patient is healthy!",
-        "worstPenaltyNote": "Wound penalty of {penalty} was sustained for {days} days this season.",
+        "penaltyAdviceHeavy": "The character can talk, eat, and move himself short distances given time and assistance. Productive activities (including study, Hermetic Lab work, and craft work) are impossible.",
         "penaltyAdviceLight": "The character can travel and study normally, but cannot undertake strenuous activities, including casting spells that cost Fatigue. Hermetic Lab work and craft work can be undertaken as normal.",
         "penaltyAdviceMedium": "The character can walk, provided he is allowed to go slowly and take frequent rests. All long-distance travel rates are halved. The character may study, but his Advancement Total is halved if he is at this level of penalty for one month or more of the season. Hermetic Lab work and craft work are impossible.",
-        "penaltyAdviceHeavy": "The character can talk, eat, and move himself short distances given time and assistance. Productive activities (including study, Hermetic Lab work, and craft work) are impossible."
+        "sunriseRoll": "Sunrise",
+        "sunsetRoll": "Sunset",
+        "worstPenaltyNote": "Wound penalty of {penalty} was sustained for {days} days this season."
       },
       "mundaneHelp": "Mundane help",
+      "overstrain": "Overstrain check",
       "recoveryBonus": "Recovery bonus",
-      "viewMedicalHistory": "View medical history"
+      "viewMedicalHistory": "View medical history",
+      "woundRecovery": "Wound recovery",
+      "woundsRecovery": "Wounds recovery"
     },
     "scriptorium": {
       "button": {
         "createActivity": "Create activity",
-        "selectBookToRead": "Select a book to read",
         "selectBookToAppend": "Select a book to append to",
         "selectBookToCopy": "Select a book to copy",
+        "selectBookToRead": "Select a book to read",
         "selectReader": "Select reader",
         "selectScribe": "Select scribe",
         "selectWriter": "Select writer"
       },
-
       "copying": {
         "activity": "Copying book",
         "finalQuality": "Final quality",
@@ -1143,6 +1143,7 @@
         "dropCharacter": "Drop a character here.",
         "dropLabText": "Drop a owned spell or draft laboratory text.",
         "emptyBook": "The book is empty, you cannot learn anything from it.",
+        "error": "An unexpected error occurred in the Scriptorium. Please check the browser console (F12) for details.",
         "illiterate": "The reader doesn't know how to read. (Artes Liberales 1+)",
         "invalidLevel": "Invalid level.",
         "invalidQuality": "Invalid quality.",
@@ -1162,8 +1163,7 @@
         "unconfirmedLang": "Please confirm that the scribe speaks all languages listed.",
         "unfamiliarTopic": "Unfamiliar topic ({topic}), any copy may be corrupted and useless (Confirm with storyguide).",
         "unfamiliarTopic2": "Confirm with the Storyguide that the scribe is skilled enough in a related ability.",
-        "whichItem": "Couldn't match any {item} known by the reader. Pick one if applicable.",
-        "error": "An unexpected error occurred in the Scriptorium. Please check the browser console (F12) for details."
+        "whichItem": "Couldn't match any {item} known by the reader. Pick one if applicable."
       },
       "quickCopy": "Quick copy",
       "reader": {
@@ -1182,8 +1182,8 @@
       },
       "writer": {
         "name": "Writer's name",
-        "nothingToWrite": "The writer has nothing to write about.",
         "noQualifyingArts": "The writer has no arts with a score of 5 or more.",
+        "nothingToWrite": "The writer has nothing to write about.",
         "title": "Writer",
         "writingScoreLabel": "Writing score (Com + language)",
         "writingScoreLabel2": "Translating score (Language x 20) levels."
@@ -1527,6 +1527,9 @@
       "modifiersLifeMundane": "Living Conditions Mod (Mundanes)",
       "money": "Money",
       "mounted": "Mounted",
+      "msg": {
+        "creationModeRemoval": "Are you sure you want to remove creation mode? Only a SG can enable it again."
+      },
       "multipleCasting": {
         "label": "Multiple Casting"
       },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,12 +1,12 @@
 {
   "TYPES": {
     "Actor": {
-      "TypeBeast": "Animal",
-      "TypeCovenant": "Alliance",
-      "TypeLaboratory": "Laboratoire",
-      "TypeMagiccodex": "Codex magique",
-      "TypeNpc": "PNJ",
-      "TypePlayer": "Personnage joueur"
+      "beast": "Animal",
+      "covenant": "Alliance",
+      "laboratory": "Laboratoire",
+      "magicCodex": "Codex magique",
+      "npc": "PNJ",
+      "player": "Personnage joueur"
     },
     "Item": {
       "Might": "Puisssance",
@@ -78,6 +78,8 @@
         "temporary": "Effets temporaires"
       },
       "subtypes": {
+        "agingMagi": "Vieillissement pour les mages",
+        "agingMundane": "Vieillissement pour les vulgaires",
         "attackRoll": "Jets d'attaque",
         "auraLevel": "Niveau de l'aura",
         "auraRealm": "Domaine de l'aura",
@@ -85,6 +87,7 @@
         "combatRoll": "Jets de combat",
         "consumables": "Fournitures",
         "defRoll": "Jet de défense",
+        "fatigueRolls": "Modificateur de jet de fatigue",
         "fatigueTotal": "Total de Fatigue",
         "formMagicRoll": "Jets de magie formulaïque",
         "inhabitantPoints": "Inhabitant points",
@@ -97,6 +100,7 @@
         "learnSpell": "Apprentissage de sort",
         "library": "Bibliothèque",
         "magicItems": "Objets magiques",
+        "magicResistance": "Resistance magique",
         "magicRoll": "Jets de magie",
         "money": "Argent",
         "none": "Aucun",
@@ -119,6 +123,7 @@
         "xpmod": "Bonus d'Xp"
       },
       "type": {
+        "covenantModifiers": "Modificateur de l'alliance",  
         "covenantBuildPoint": "Points de construction de l'alliance",
         "covenantInhabitants": "Les habitants de l'Alliance",
         "spellcasting": "Lancement de Sorts",
@@ -130,6 +135,7 @@
       },
       "types": {
         "AlternateArtBonus": "Bonus d'Arts alternatifs",
+        "AlternateArtXPBonus": "Bonus d'XP aux Arts alternatifs",
         "academicAbilitiesAffinity": "Affinité Compétences Académiques (xp)",
         "academicAbilitiesBonus": "Bonus aux Compétences Académiques",
         "academicAbilitiesXPBonus": "Bonus d'XP aux compétences Académiques",
@@ -144,6 +150,7 @@
         "characteristicBoost": "Augmentation de Caractéristique",
         "characteristics": "Caractéristiques",
         "fatigue": "Fatigue",
+        "formMagicResistance": "Résistance magique à la Forme",
         "formResistance": "Résistance naturelle",
         "generalAbilitiesAffinity": "Affinité Compétences Générales (xp)",
         "generalAbilitiesBonus": "Bonus aux Compétences Générales",
@@ -375,12 +382,22 @@
       }
     },
     "chat": {
-      "contestOfMagic": "Concours de Magie",
+      "contestOfMagic": "Confrontation magique",
+      "contestOfMagicWith": "Confrontation magique avec {name}",
+      "notifications": {
+        "notInitiator": "Non autorisé car vous n'êtes pas l'initiateur du jet. Demandez à l'initiateur du jet ou au Conteur."
+      },
+      "otherMagicResistance": "Autre résistance magique",
       "totalMagicResistance": "Total de Résistance Magique"
     },
     "combat": {
       "damage": {
         "ignored": "Jet de dés ignoré"
+      },
+	  "targets": {
+        "multiple": "Cibles multiples",
+        "none": "Pas de cible sélectionnée",
+        "single": "Une seule cible"
       }
     },
     "config": {
@@ -415,12 +432,24 @@
         "none": "Aucun salaire",
         "normal": "Salaire normal",
         "pension": "Pension"
+      },
+      "inhabitantsMod": {
+        "laborers": "Manoeuvriers magique",
+        "turbula": "Turbula magique",
+        "servants": "Servants magique",
+        "teamsters": "Transporteurs magique"
       }
     },
     "damage": {
+      "compute": "Calcul des dommages",
+      "damageflavor": "{amount} poitns de dommage à encaisser de {source}",
       "form": "Dommage de forme",
+      "ignoreArmor": "Ignore l'armure",
       "label": "Dommages",
-      "roll": "Jet de dommage"
+      "roll": "Jet de dommage",
+      "soakFlavor": "Encaissement de {amount} de dommage dont la source est {source}",
+      "source": "Source des dommages",
+      "sourcePlaceHolder": "Description de la source"
     },
     "dialog": {
       "botch": {
@@ -511,6 +540,7 @@
       "always": "Toujours",
       "base": "Base",
       "begins": "Débuts",
+      "cancelled": "Annuler",
       "clear": "Effacer",
       "config": "Configurer",
       "current": "Actuel",
@@ -529,6 +559,9 @@
       "minutes": "minutes",
       "minutesShort": "min.",
       "modifier": "Modificateur",
+      "modifiers": "Modificateurs",
+      "missed": "Raté",
+      "misc": "Divers",
       "multiplier": "Multiplicateur",
       "multipliers": "Multiplicateurs",
       "na": "N/A",
@@ -544,6 +577,7 @@
       "other": "Autre",
       "params": "Paramètres",
       "pending": "En attente",
+      "refresh": "Actualiser",
       "special": "Spécial",
       "standard": "Standard",
       "summary": "Résumé",
@@ -786,6 +820,7 @@
       "fatigueLost": "Perdre {num} niveau(x) de fatigue",
       "noConf": "Utilisation d'un point de confiance",
       "noWound": "Aucune blessure",
+      "soak": "Jet d'encaissement",	  
       "useConf": "Utiliser un Point de Confiance",
       "wound": {
         "dead": "Mort",
@@ -813,6 +848,7 @@
           }
         }
       },
+      "damagePending": "Un jet de dommages est en attente pour ce personnage. Vous devriez peut-être l'encaisser avant de lancer autre chose.",
       "dead": "Ce personnage est mort...",
       "doubleAbility": "Ce personnage a déjà cette compétence",
       "effectLinked": "Suppression impossible. Un effet est lié à cette capacité.",
@@ -1030,21 +1066,21 @@
         "logWoundBetter": "Amélioration de la blessure en {days} jours",
         "logWoundStable": "Blessure stabilisée",
         "logWoundWorse": "La blessure s'aggrave au bout de {days} jours",
+        "nextSeason": "Passage à {season} {year}.",
         "noWoundsForOverstrain": "Aucune blessure active pour un jet de surmenage.",
         "notOpen": "Ouvrez d'abord la fenêtre du Sanatorium, puis lancez le dé depuis ici.",
-        "nextSeason": "Passage à {season} {year}.",
         "overstrainNote": "Aggravée par surmenage en {season} {year}.",
         "overstrainStable": "La blessure tient — pas d'aggravation due au surmenage.",
         "overstrainWorsened": "{name} s'est aggravée en {type} à cause du surmenage !",
-        "sunriseRoll": "Lever du soleil",
-        "sunsetRoll": "Coucher du soleil",
         "patientDead": "Le patient est mort !",
         "patientDied": "Le patient est mourrant !",
         "patientHealthy": "Le patient est en bonne santé !",
-        "worstPenaltyNote": "Pénalité de blessure de {penalty} soutenue pendant {days} jours cette saison.",
+        "penaltyAdviceHeavy": "Le personnage peut parler, manger et se déplacer sur de courtes distances avec du temps et de l'aide. Les activités productives (y compris l'étude, le travail en laboratoire hermétique et les travaux artisanaux) sont impossibles.",
         "penaltyAdviceLight": "Le personnage peut voyager et étudier normalement, mais ne peut pas entreprendre d'activités épuisantes, notamment lancer des sorts qui coûtent de la Fatigue. Le travail en laboratoire hermétique et les travaux artisanaux peuvent être effectués normalement.",
         "penaltyAdviceMedium": "Le personnage peut marcher, à condition qu'on lui permette d'aller lentement et de se reposer fréquemment. Toutes les vitesses de déplacement longue distance sont réduites de moitié. Le personnage peut étudier, mais son Total d'Avancement est divisé par deux s'il est à ce niveau de pénalité pendant un mois ou plus de la saison. Le travail en laboratoire hermétique et les travaux artisanaux sont impossibles.",
-        "penaltyAdviceHeavy": "Le personnage peut parler, manger et se déplacer sur de courtes distances avec du temps et de l'aide. Les activités productives (y compris l'étude, le travail en laboratoire hermétique et les travaux artisanaux) sont impossibles."
+        "sunriseRoll": "Lever du soleil",
+        "sunsetRoll": "Coucher du soleil",
+        "worstPenaltyNote": "Pénalité de blessure de {penalty} soutenue pendant {days} jours cette saison."
       },
       "mundaneHelp": "Aide vulgaire",
       "recoveryBonus": "Bonus de récupération",
@@ -1083,6 +1119,7 @@
         "dropBookTopic": "Déposer un livre ici et choisissez un sujet.",
         "dropCharacter": "Faire glisser un personnage ici.",
         "dropLabText": "Déposez ici un sort connu ou un texte de laboratoire.",
+        "error": "Une erreur inattendue s'est produite dans le Scriptorium. Vérifiez la console du navigateur (F12) pour plus de détails.",
         "illiterate": "Le lecteur ne sait pas lire. (Artes Liberales 1+)",
         "invalidLevel": "Niveau invalide.",
         "invalidQuality": "Qualité invalide",
@@ -1102,8 +1139,7 @@
         "unconfirmedLang": "Merci de confirmer que le scribe parle toute les langues listées.",
         "unfamiliarTopic": "Sujet inconnu ({topic}), toute copie peut être corrompue et inutile (Confirmer avec le maître de jeu).",
         "unfamiliarTopic2": "Confirmer auprès du Maitre de jeu que le scribe est suffisamment compétent dans une compétence connexe.",
-        "whichItem": "Ne correspond à aucune {item} connu du lecteur. Choisissez-en un, le cas échéant.",
-        "error": "Une erreur inattendue s'est produite dans le Scriptorium. Vérifiez la console du navigateur (F12) pour plus de détails."
+        "whichItem": "Ne correspond à aucune {item} connu du lecteur. Choisissez-en un, le cas échéant."
       },
       "quickCopy": "Copie rapide",
       "reader": {
@@ -1160,6 +1196,8 @@
       "age": "Âge",
       "ageModifier": "Modificateur d'Âge",
       "aging": "Vieillissement",
+      "agingMagi": "Vieillissement pour les mages",
+      "agingMundane": "Vieillissement pour les vulgaires",	  
       "agingPts": "Points de Vieillissement",
       "agingStart": "Décalage du début du vieillissement",
       "apparentAge": "Âge apparent",
@@ -1216,16 +1254,20 @@
       "child": "Enfant",
       "com": "Com",
       "combat": {
+        "defend": "Défense",
         "flavor": {
           "attack": "{attacker} attaque {target} avec {weapon}.",
           "damage": "{attacker} essaye d'infliger des dégats.",
           "damageSource": "Source des dégats",
+          "damageWithTarget": "{attacker} tente d'infliger {amount} points de dommage à {target}.",
           "defense": "{defender} se défend contre {attacker} avec {weapon}.",
           "defenseNoAttacker": "{defender} défends avec {weapon}.",
           "noWeapon": "sans arme",
-          "soak": "{target} évite les dégats."
+          "soak": "{target} encaisse les dégats."
         },
-        "label": "Combat"
+        "label": "Combat",
+        "preparation": "Préparation au combat",
+        "wound": "Blessure de combat infligé par {attacker}"
       },
       "combatInstructions1": "Équipez des armes et armures pour voir le total",
       "combatInstructions2": "Si votre spécialité est avec le bouclier, marquez le sur le bouclier et non pas l'arme. Si vous n'avez pas le bouclier d'équippé, le bonus de spécialté ne s'applique pas.",
@@ -1298,8 +1340,10 @@
         "label": "Vitesse d'Incantation Rapide"
       },
       "fatigue": {
+        "add": "Ajoute un niveau de fatique (Shift+Clic pour fatigue à long terme).",
         "label": "Fatigue",
         "overflow": "Excès de fatigue",
+        "recover": "Enlève un niveau de fatique (Shift+Clic pour fatigue à long terme).",
         "roll": "Jet de fatigue"
       },
       "features": "Traits distinctifs",
@@ -1361,6 +1405,7 @@
       "initials": "Départ",
       "initiations": "Initiatique",
       "initiative": "Initiative",
+      "initiativeShort": "Init",
       "int": "Int",
       "intelligence": "Intelligence",
       "inventory": "Inventaire",
@@ -1457,6 +1502,7 @@
       "modifiersLifeMagi": "Mod. aux conditions de vie (Magi)",
       "modifiersLifeMundane": "Mod. aux conditions de vie (Vulgaires)",
       "money": "Argent",
+      "mounted": "Monté",
       "multipleCasting": {
         "label": "Lancement Multiple"
       },
@@ -1468,6 +1514,7 @@
       "narrator": "Conteur",
       "natRes": "Résistance naturelle",
       "nationality": "Ethnie/Nationalité",
+      "naturalweapon": "Arme naturelle",
       "naturalweapons": "Armes naturelles",
       "noMagicResistance": "Pas de résistance magique",
       "none": "Aucun",
@@ -1550,10 +1597,12 @@
       "salubrity": "Salubrité",
       "sanctum": "Sanctum",
       "saving": "Réductions",
+      "scene": "Scène",	  
       "score": "Score",
       "season": "Saison",
       "seasons": "Saisons",
-      "security": "**Sécurité**",
+      "secrets": "Secrets",
+      "security": "Sécurité",
       "servants": "Serviteurs",
       "setAbilities": "Créez des compétences pour votre personnage pour les valeurs ci-dessous. Celà permet le calcul correct. Si vous ne possédez pas la capacité, vous pouvez tout de même la créer avec une valeur de zéro",
       "sigil": "Sceau du Magicien",
@@ -1648,6 +1697,9 @@
       "standard": "Moyen",
       "state": {
         "label": "Statut"
+      },
+      "states": {
+        "confidencePrompt": "Dépense de Confiance en attente"
       },
       "story": "Histoire",
       "str": "For",

--- a/lang/it.json
+++ b/lang/it.json
@@ -585,6 +585,7 @@
         },
         "dropBook": "Trascina un libro qui per riempire gli spazi vuoti.",
         "dropCharacter": "Trascina un personaggio qui.",
+        "error": "Si è verificato un errore imprevisto nello Scriptorium. Controllare la console del browser (F12) per i dettagli.",
         "illiterate": "Il lettore non sa leggere.",
         "invalidLevel": "Livello non valido.",
         "invalidQuality": "Qualità non valida.",
@@ -593,8 +594,7 @@
         "notMagus": "Il lettore non è un magus.",
         "tooSkilled": "Il lettore è troppo esperto per quel libro.",
         "tractAlreadyRead": "Il lettore ha già letto un trattato con lo stesso titolo",
-        "whichItem": "Non è stato possibile appaiare alcun {item} conosciuto dal lettore. Scegline uno se applicabile.",
-        "error": "Si è verificato un errore imprevisto nello Scriptorium. Controllare la console del browser (F12) per i dettagli."
+        "whichItem": "Non è stato possibile appaiare alcun {item} conosciuto dal lettore. Scegline uno se applicabile."
       },
       "reader": {
         "name": "Nome del lettore",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,53 +1,4 @@
 {
-  "ACTOR": {
-    "TypeBeast": "Fera",
-    "TypeCovenant": "Concílio",
-    "TypeLaboratory": "Laboratório",
-    "TypeMagiccodex": "Códice Mágico",
-    "TypeNpc": "PdM",
-    "TypePlayer": "Personagem do Jogador"
-  },
-  "ITEM": {
-    "TypeAbility": "Habilidade",
-    "TypeAbilityfamiliar": "Habilidade do Familiar",
-    "TypeArmor": "Armadura",
-    "TypeBaseeffect": "Efeito base (interno)",
-    "TypeBook": "Livro",
-    "TypeCalendarcovenant": "Evento do calendário (interno)",
-    "TypeDiaryentry": "Registro do Diário (Interno)",
-    "TypeDistinctive": "Característica de Laboratório (obsoleto)",
-    "TypeEnchantment": "Encantamento",
-    "TypeFlaw": "Defeito",
-    "TypeHabitanthorses": "Cavalos do Concílio",
-    "TypeHabitantlivestock": "Gados do concílio",
-    "TypeHabitantmagi": "Magus habitante (obsoleto)",
-    "TypeHabitantmompanion": "Companheiro habitante (obsoleto)",
-    "TypeHabitantspecialists": "Especialista habitante (obsoleto)",
-    "TypeHook": "Gancho",
-    "TypeIncomingsource": "Fonte de renda",
-    "TypeInhabitant": "Habitante do concílio",
-    "TypeItem": "Item",
-    "TypeLaboratorytext": "Texto de laboratório",
-    "TypeMagicaleffect": "Efeito Mágico",
-    "TypeMagicitem": "Item Mágico (obsoleto)",
-    "TypeMight": "Potência",
-    "TypeMightfamiliar": "Potência de Familiar",
-    "TypeMundanebook": "Livro mundano (obsoleto)",
-    "TypePersonalitytrait": "Traço de Personalidade",
-    "TypePossessionscovenant": "Posses do concílio",
-    "TypePower": "Poder",
-    "TypePowerfamiliar": "Poder de Familiar",
-    "TypeReputation": "Reputação",
-    "TypeSanctumroom": "Sala do Sanctum (obsoleto)",
-    "TypeSpeciality": "Especialidade de Laboratório (obsoleto)",
-    "TypeSpell": "Magia",
-    "TypeVirtue": "Virtude",
-    "TypeVis": "Vis",
-    "TypeVissourcescovenant": "Fontes de vis do concílio",
-    "TypeVisstockcovenant": "Estoques de vis do concílio",
-    "TypeWeapon": "Arma",
-    "TypeWound": "Ferimento"
-  },
   "TYPES": {
     "Actor": {
       "beast": "Fera",
@@ -72,11 +23,12 @@
       "flaw": "Defeito",
       "habitantCompanion": "Companheiro habitante (obsoleto)",
       "habitantHorses": "Cavalos do concílio",
-      "habitantLivestock": "Gados do concílio",
-      "habitantMagi": "Magus habitante (obsoleto)",
+      "habitantLivestock": "Gado do concílio",
+      "habitantMagi": "Magi habitante (obsoleto)",
       "habitantSpecialists": "Especialista habitante (obsoleto)",
       "hook": "Gancho",
       "incomingSource": "Fonte de renda",
+      "inferiority": "Inferioridade",
       "inhabitant": "Habitante do concílio",
       "item": "Item",
       "laboratoryText": "Texto de laboratório",
@@ -87,6 +39,7 @@
       "possessionsCovenant": "Posses do concílio",
       "power": "Poder",
       "powerFamiliar": "Poder de Familiar",
+      "quality": "Qualidade",
       "reputation": "Reputação",
       "sanctumRoom": "Sala do Sanctum (obsoleto)",
       "speciality": "Especialidade de laboratório (obsoleto)",
@@ -107,7 +60,7 @@
         "penetration": "Bônus de penetração"
       },
       "changeMode": "Mudar Modo",
-      "changeValue": "Valor do efeito",
+      "changeValue": "Valor do Efeito",
       "info": {
         "noedit": "Nota: Criação de efeito ativo é impossível se o item é possuído por um Ator, edite o efeito original e faça uma cópia no seu mundo para editar."
       },
@@ -125,6 +78,8 @@
         "temporary": "Efeitos temporários"
       },
       "subtypes": {
+        "agingMagi": "Envelhecendo para Magi",
+        "agingMundane": "Envelhecendo para Mundanos",
         "attackRoll": "Rolagens de ataque",
         "auraLevel": "Nível da aura",
         "auraRealm": "Reino da aura",
@@ -132,6 +87,7 @@
         "combatRoll": "Rolagens de combate",
         "consumables": "Consumíveis",
         "defRoll": "Rolagens de defesa",
+        "fatigueRolls": "Modificador de testes de fadiga",
         "fatigueTotal": "Total de fadiga",
         "formMagicRoll": "Rolagens de magia formulaica",
         "inhabitantPoints": "Pontos de habitantes",
@@ -144,16 +100,19 @@
         "learnSpell": "Aprender magia",
         "library": "Biblioteca",
         "magicItems": "Encantamentos",
+        "magicResistance": "Resistência mágica",
         "magicRoll": "Rolagens de magia",
         "money": "Dinheiro",
         "none": "Nenhum",
         "provisions": "Provisões",
+        "ritualFatigueCancelled": "Níveis de fadiga ritual cancelados",
         "servants": "Servos",
         "specialists": "Especialistas",
+        "spellFatigueThreshold": "Limiar de fadiga de magia",
         "spontDivider": "Divisor de magia esp.",
         "spontDividerNoFatigue": "Divisor de magia esp. sem fadiga",
         "spontMagicRoll": "Rolagens de magia espontânea",
-        "teamsters": "Abastecedores",
+        "teamsters": "Transportadores",
         "turbula": "Guardas",
         "vis": "Vis",
         "wages": "Salários",
@@ -166,6 +125,7 @@
       "type": {
         "covenantBuildPoint": "Pontos de construção do concílio",
         "covenantInhabitants": "Habitantes do concílio",
+        "covenantModifiers": "Modificadores do concílio",
         "spellcasting": "Conjuração",
         "yearlyExpenses": "Despesas do concílio",
         "yearlySavings": {
@@ -175,38 +135,48 @@
       },
       "types": {
         "AlternateArtBonus": "Bônus p/ Artes Alternativas",
+        "AlternateArtXPBonus": "Bônus de EXP p/ Artes Alternativas",
         "academicAbilitiesAffinity": "Afinidade c/ Hab. Acadêmicas (Exp)",
         "academicAbilitiesBonus": "Bônus p/ Hab. Acadêmicas",
+        "academicAbilitiesXPBonus": "Bônus de EXP p/ Hab. Acadêmicas",
         "affinityAlternateArt": "Afinidade c/ Artes Alternativas (Exp)",
         "arcaneAbilitiesAffinity": "Afinidade c/ Hab. Arcanas (Exp)",
         "arcaneAbilitiesBonus": "Bônus p/ Hab. Arcanas",
+        "arcaneAbilitiesXPBonus": "Bônus de EXP p/ Hab. Arcanas",
         "arts": {
           "affinity": "Afinidade com arte",
           "deficiency": "Deficiência com arte"
         },
+        "characteristicBoost": "Aumento da característica",
         "characteristics": "Características",
         "fatigue": "Fadiga",
+        "formMagicResistance": "Resistência mágica à forma",
         "formResistance": "Resistência natural",
         "generalAbilitiesAffinity": "Afinidade c/ Hab. Gerais (Exp)",
         "generalAbilitiesBonus": "Bônus p/ Hab. Gerais",
+        "generalAbilitiesXPBonus": "Bônus de EXP p/ Hab. Gerais",
         "labActivity": "Atividade de lab. do personagem",
         "laboratoryAttr": "Características de Laboratório",
         "laboratorySpec": "Especialidade de Laboratório",
         "martialAbilitiesAffinity": "Afinidade c/ Hab. Marciais (Exp)",
         "martialAbilitiesBonus": "Bônus p/ Hab. Marciais",
+        "martialAbilitiesXPBonus": "Bônus de EXP p/ Hab. Marciais",
         "mysteryAbilitiesAffinity": "Afinidade c/ Hab. de Mistério (Exp)",
         "mysteryAbilitiesBonus": "Bônusp/ Hab. Mistério",
+        "mysteryAbilitiesXPBonus": "Bônus de EXP p/ Hab. de Mistério",
         "nullEffect": "Efeito nulo",
         "optional": "Bônus opcional",
+        "qualityAbilityBoost": "Qualidade - Bônus de Habilidade",
         "realmAlignment": "Alinhamento de Reino",
+        "realmSusceptibility": "Suscetibilidade do reino",
         "roll": {
           "optional": "Bônus de rolagem opcional"
         },
         "spellmastery": "Aperfeiçoamento de magia",
         "supernaturalAbilitiesAffinity": "Afinidade c/ Hab. Sobrenaturais (Exp)",
         "supernaturalAbilitiesBonus": "Bônus p/ Hab.Sobrenaturais",
-        "supernaturalAbilitiesXPBonus": "Bônus EXP de Hab. Sobrenaturais",
-        "vitals": "Vitas",
+        "supernaturalAbilitiesXPBonus": "Bônus de EXP p/ Hab. Sobrenaturais",
+        "vitals": "Vitais",
         "wounds": "Ferimentos"
       }
     },
@@ -242,6 +212,7 @@
       "msg": {
         "abilityMissing": "Essa habilidade não existe mais.",
         "activityEndsInFuture": "Impossível aplicar. Esta atividade termina no futuro",
+        "activityStartsInFuture": "Impossível aplicar. Esta atividade começa no futuro",
         "agingInWinter": "Envelhecimento normalmente ocorre no inverno ao menos que haja um efeito externo.",
         "duplicates": "Esses são duplicados {param}",
         "gainCapped": "A experiência ganha foi limitada a {param}, o estudante irá alcançar seu mestre.",
@@ -249,7 +220,8 @@
         "noAbility": "Nenhuma habilidade restante",
         "noArt": "Nenhuma arte restante",
         "noEnoughVis": "Vis insuficiente em estoque.",
-        "noProgressItems": "Sem progreso para os itens selecionados.",
+        "noProgressItems": "Sem progresso para os itens selecionados.",
+        "noProgressPossible": "Não há progresso possível na data atual.",
         "noSpell": "Nenhuma magia restante",
         "noTeacher": "Nenhum professor(a) selecionado(a).",
         "noTrainer": "Nenhum treinador(a) selecionado(a).",
@@ -282,7 +254,9 @@
         "masteries": "Aperfeiçoamentos"
       },
       "reading": "Leitura",
+      "readingArts": "Lendo sobre artes",
       "recovery": "Recuperação",
+      "resource": "Rastreamento de recursos",
       "roll": {
         "aging": "Rolar para envelhecimento",
         "investigate": "Rolar para investigar",
@@ -314,6 +288,21 @@
         "teaching": "Aprendendo {skills} com {teacher}",
         "training": "Treinando {skills} com {teacher}",
         "visStudy": "Estudo de {art} Vis"
+      },
+      "tracking": {
+        "addition": "{resource} adicionado ao inventário.",
+        "from": {
+          "generic": "{toActor} recebeu {resource} de {fromActor}.",
+          "vis": "{resource} colhido de {fromActor}.",
+          "visSource": "{resource} colhido de {fromActor}."
+        },
+        "removal": "{resource} removido do inventário.",
+        "resource": {
+          "vis": "{num} peão(s) de {art} Vis"
+        },
+        "to": {
+          "generic": "{fromActor} deu {resource} para {toActor}."
+        }
       },
       "training": "Treinamento",
       "visStudy": "Estudo de vis",
@@ -366,8 +355,11 @@
       "summary": "Resumo de envelhecimento"
     },
     "astrolab": {
+      "nextSeason": "Próxima estação",
+      "prevSeason": "estação anterior",
       "restAll": "Descansar todos",
       "setWorldDate": "Definir data do mundo",
+      "trackResources": "Rastrear recursos",
       "updateActors": "Atualizar atores"
     },
     "book": {
@@ -391,19 +383,33 @@
     },
     "chat": {
       "contestOfMagic": "Contestação de Magia",
+      "contestOfMagicWith": "Concurso de magia com {name}",
+      "notifications": {
+        "notInitiator": "Não autorizado porque você não é o iniciador da rolagem. Pergunte a ele ou a um GM"
+      },
+      "otherMagicResistance": "Outra resistência mágica",
       "totalMagicResistance": "Total de resistência mágica"
     },
     "combat": {
       "damage": {
         "ignored": "Ignorado na rolagem"
+      },
+      "targets": {
+        "multiple": "Vários alvos",
+        "none": "Nenhum destino selecionado",
+        "single": "Alvo único"
       }
     },
     "config": {
       "compendiaRef": "Referência de compêndio",
+      "currency": {
+        "name": "Moedas de prata"
+      },
       "hint": {
         "compendiaRef": "Selecione o modulo que servirá como referência para o conteúdo de compêndio do sistema"
       },
-      "sourcebookFilter": "Filtro de livros"
+      "sourcebookFilter": "Filtro de livros",
+      "sourcebooks": "Livros de referência"
     },
     "covenant": {
       "equipment": {
@@ -411,6 +417,12 @@
         "low": "Modesto",
         "standard": "Normal",
         "standardPlus": "Normal + uma peça valiosa"
+      },
+      "inhabitantsMod": {
+        "laborers": "Trabalhadores Mágicos",
+        "servants": "Servos Mágicos",
+        "teamsters": "Caminhoneiros Mágicos",
+        "turbula": "Guardas Mágicos"
       },
       "specialist": {
         "books": "Bibliotecário",
@@ -430,8 +442,15 @@
       }
     },
     "damage": {
+      "compute": "Calcular dano",
+      "damageflavor": "{amount} de dano a ser absorvido de {source}",
+      "form": "Formulário de Dano",
+      "ignoreArmor": "Ignorar armadura",
       "label": "Dano",
-      "roll": "Rolagem de dano"
+      "roll": "Rolagem de dano",
+      "soakFlavor": "Absorva {amount} dos danos de {source}",
+      "source": "Fonte de dano",
+      "sourcePlaceHolder": "Uma fonte de dano"
     },
     "dialog": {
       "botch": {
@@ -469,9 +488,14 @@
         "abilityOption": "Apenas caracteres alfanuméricos."
       },
       "magicItemUse": "Usar item mágico",
+      "noDocuments": "Nenhum documento encontrado.",
+      "pickActors": "Escolha atores",
+      "pickDocuments": "Escolha documentos",
+      "pickItems": "Escolha itens",
       "powerUse": "Usar poder",
       "roll": {
         "exploding": {
+          "modifier": "Modificador atual",
           "multiplier": "Modificador atual"
         },
         "explodingroll": "Dados explodiram! Role novamente!"
@@ -511,7 +535,9 @@
       }
     },
     "feature": {
-      "magicSystem": "Sistema de magia alternativa - EXPERIMENTAL"
+      "inteligentBeast": "Besta inteligente",
+      "magicSystem": "Sistema de magia alternativa - EXPERIMENTAL",
+      "powers": "Poderes"
     },
     "generic": {
       "abort": "Abortar",
@@ -519,17 +545,29 @@
       "always": "Sempre",
       "base": "Base",
       "begins": "Começa",
+      "cancelled": "Cancelado",
+      "clear": "Claro",
       "config": "Configuração",
+      "confirm": "Confirmar",
       "current": "Atual",
       "custom": "Customizado",
       "default": "Padrão",
       "details": "Detalhes",
+      "difficulty": "Dificuldade",
       "ends": "Termina",
       "hidden": "Escondido",
+      "hours": "horas",
+      "hoursShort": "h.",
       "info": "Informação",
+      "inherit": "Herdar",
       "invalid": "Inválido",
       "locked": "Trancado",
+      "minutes": "minutos",
+      "minutesShort": "min.",
+      "misc": "Variado",
+      "missed": "Perdido",
       "modifier": "Modificador",
+      "modifiers": "Modificadores",
       "multiplier": "Multiplicador",
       "multipliers": "Multiplicadores",
       "na": "N/A",
@@ -544,15 +582,23 @@
       "orphans": "Orfãos",
       "other": "Outro",
       "params": "Paramêtros",
+      "pending": "Pendente",
+      "refresh": "Atualizar",
+      "special": "Especial",
       "standard": "Padrão",
       "summary": "Resumo",
       "template": "Modelo",
       "templates": "Modelos",
       "total": "Total",
       "unknown": "Desconhecido",
+      "update": "Atualizar",
+      "value": "Valor",
+      "versus": "Contra",
       "yes": "Sim"
     },
     "hints": {
+      "add": "Adicionar {item}",
+      "clone": "Clonar {item}",
       "copy": "Copiar {item}",
       "create": "Criar {item}",
       "createLabText": "Criar rascunho de texto de lab.",
@@ -561,11 +607,13 @@
       "edit": "Editar {item}",
       "read": "Ler {item}",
       "recover": "Recuperar-se de {item}",
-      "useMagicItem": "Ativar o efeito \"{name}\""
+      "useMagicItem": "Ativar o efeito \"{name}\"",
+      "view": "Ver {item}"
     },
     "lab": {
       "activity": {
         "chargedEnchantment": "Item Efêmero",
+        "enchanting": "Encantador",
         "inventSpell": "Invenção de magia",
         "itemInvestigation": "Investigação de encantamento",
         "label": "Atividade de Laboratório",
@@ -574,17 +622,21 @@
         "minorEnchantment": "Encantamento inferior",
         "openEnchantment": "Preparar encantamento",
         "spellLearning": "Aprendizagem de magia",
+        "title": {
+          "longevityRitual": "Ritual de longevidade para {name}"
+        },
         "visExtraction": "Extração de Vis"
       },
       "bonus": {
         "activity": "Modificador de atividade",
         "apprentice": "Aprendiz",
         "aspects": "Bônus de forma e material",
-        "aspectsMax": "máximo dobro de Teoria M.",
+        "aspectsMax": "máximo de Teoria Mágica",
         "aspectsVerditius": "Philosophiae (Verditius)",
         "aura": "Aura",
         "generic": "Modificador genérico",
         "labQuality": "Qualidade de lab.",
+        "moreVisUsed": "Vis adicional usado",
         "specialties": "Especialidades"
       },
       "distraction": {
@@ -601,6 +653,7 @@
           "appraisal": "Avaliação",
           "charges": "Usos",
           "compounded": "Composto",
+          "enable": "Habilitar encantamento",
           "expiry": {
             "1y": "1 ano",
             "70y": "70 anos",
@@ -664,6 +717,7 @@
       "option": {
         "oneCharge": "Um uso por item"
       },
+      "otherSubject": "Outro assunto",
       "planning": {
         "button": {
           "refresh": "Atualizar",
@@ -675,9 +729,7 @@
           "botched": "Falha crítica na investigação com {botches} falhas.",
           "diaryTitle": "Investigação de \"{name}\"",
           "foundEffect": "Novo efeito encontrado! : {effect}.",
-          "nothingFound": {
-            "": "Nada mais encontrado."
-          },
+          "nothingFound": "Nada mais encontrado.",
           "rolled": "Rolou {total} (die + {labTotal})"
         },
         "knownEffects": "Efeitos conhecidos",
@@ -691,6 +743,7 @@
           "dropItemToInvestigate": "Solte um encantamento para investigar",
           "insufficientLabTotal": "Total de Laboratório {arts} insuficiente para extrair vis.",
           "labTotalExcess": "Pontos de lab. excedentes: {points}.",
+          "labTotalTooLow": "O total do laboratório é muito baixo para criar um ritual de longevidade para outro.",
           "longevityBonus": "Bônus de {bonus} para envelhecimento.",
           "noOwner": "Esse lab. não tem dono. Planejamento não é possível.",
           "notSkilledEnchant": "Habilidade insuficiente para encantar este item.",
@@ -707,10 +760,13 @@
           "wounded": "Aviso: personagem está ferido ({penalty}), verifique se isto se aplica ao Total de Lab."
         }
       },
+      "ritualSubject": "Assunto do ritual",
+      "self": "Auto",
       "specialty": {
         "experimentation": "Experimentação",
         "familiar": "Familiar",
         "items": "Itens",
+        "label": "Especialidade do laboratório",
         "longevityRituals": "Rituais de longevidade",
         "spells": "Magias",
         "texts": "Textos",
@@ -769,7 +825,9 @@
         "warpGain": "Ganhou {num} ponto(s) de distorção"
       },
       "fatigueLost": "Perdeu {num} nível(is) de fadiga",
+      "noConf": "Pular uso de determinação",
       "noWound": "Nenhum ferimento infligido",
+      "soak": "Mergulhe o rolo",
       "useConf": "Usar ponto de determinação",
       "wound": {
         "dead": "fatal",
@@ -786,6 +844,7 @@
         "none": "Você não tem um Ator do tipo 'magicCodex' em seu mundo, algumas funcionalidades estarão desativadas/não funcionando, você pode importa um no compendium Magi",
         "tooMany": "Você tem mais de um Ator do tipo 'magicCodex' no seu mundo, algumas funcionalidades são baseadas em um códice único, você pode querer deletar um (após integra-los se preciso)"
       },
+      "confidencePromptPending": "Há um gasto de determinação pendente no chat. Resolva ou clique no ícone de status ao lado do nome do personagem.",
       "crucible": {
         "labTotal": {
           "needed": "Total de Lab. necessário"
@@ -796,9 +855,11 @@
           }
         }
       },
+      "damagePending": "Há uma jogada de dano pendente para este personagem. Você pode querer absorve-la antes de rolar outra coisa.",
       "dead": "Este personagem está morto...",
       "doubleAbility": "O personagem já tem esta habilidade",
       "effectLinked": "Impossível deletar. Um efeito está vinculado a capacidade.",
+      "entityWithMultipleRealmAlignments": "Este personagem com Potência está alinhado com vários reinos. Verifique os efeitos ativos.",
       "incapacited": "Este personagem está gravemente ferido, nenhuma ação é possível...",
       "itemMoved": "O item \"{name}\" foi movido e não pode mais ser encontrado.",
       "missingSpell": "Magia \"{spellName}\" não existe ou foi movida. Abortando.",
@@ -811,13 +872,16 @@
       "notMagus": "Esse personagem não é um magus/maga.",
       "notPossibleToCalculateWound": "Não é possível calcular o ferimento (verifique o tamanho do personagem)",
       "pendingCrisis": "Este personagem tem uma crise de envelhecimento pendente, nenhuma ação é possível... resolva a crise clicando na caveira ao lado do nome do personagem",
+      "pendingTwilight": "Este personagem tem um episódio de Crepúsculo pendente, nenhuma rolagem possível até ser resolvida. (Shift clique como GM para remover este status)",
       "roll": {
         "botchNum": "Por favor, entre o número de dados de falha."
       },
       "setDate": "A data atual foi definida para o(a) {season} de {year}",
       "situationHasChanged": "A situação mudou, aplicar não é mais possível.",
       "synchActors": "Todos atores foram sincronizados para o(a) {season} de {year}",
-      "unconscious": "Este personagem está inconsciente, nenhuma ação é possível..."
+      "unconscious": "Este personagem está inconsciente, nenhuma ação é possível...",
+      "valueMax": "O valor não pode ser superior a {max}. Configuração no máximo.",
+      "valueMin": "O valor não pode ser inferior a {min}. Configuração no mínimo."
     },
     "packs": {
       "abilities": {
@@ -832,26 +896,179 @@
       "magic": "Mágico",
       "mundane": "Mundano",
       "nightModifier": "Modificador Noturno",
+      "susceptible": {
+        "impact": "Devido à suscetibilidade a {realm}, dividido por {divisor}"
+      },
       "visible": "Visível",
       "visibleHint": "Mostrar ou esconder mod. de aura quando rolando"
     },
     "rolltables": {
-      "experimentation": ""
+      "experimentation": {
+        "createJournal": "Criar diário",
+        "disaster": {
+          "1botch": "Todos no laboratório ganham Pontos de Distorção igual ao número de zeros na jogada de falha crítica. Os magi herméticos (e qualquer outra pessoa aberta às Artes Herméticas) devem rolar para Crepúsculo se ganharem dois ou mais; membros de outras tradições também podem sofrer efeitos graves, conforme determinado pela sua tradição. A estação está completamente perdida; veja Falha Completa. Se houver outros resultados e os magi optarem por não resistir ao Crepúsculo, eles entrarão no Crepúsculo antes que os efeitos ocorram e, assim, evitarão qualquer dano pessoal.",
+          "2botches": "Sua criação está destruída. Se for um projeto de estação única, isso equivale a um fracasso total.",
+          "3botches": "Seu laboratório ganha o Defeito Danificado.",
+          "4botches": "Explosão! Seu laboratório ganha o Defeito Destruído (em vez do Defeito Danificado), e qualquer pessoa no laboratório sofre dois Ferimentos Graves.",
+          "5botches": "O narrador da história escolhe uma das seguintes opções: <br/><ul><li>Um evento da história ameaça todo o concílio. Isso pode surgir imediatamente da explosão (um incêndio mundano, por exemplo) ou pode ser um efeito colateral persistente da magia descontrolada, causando uma história algum tempo depois.</li>.<li>A explosão destrói completamente o laboratório. A estrutura ganha os Defeitos Deformado e Instável, e todo o laboratório deve ser reconstruído do zero, em vez de ganhar o Defeito Destruído. Qualquer pessoa no laboratório sofre um Ferimento Incapacitante adicional.</li></ul>",
+          "avoid": "Você evita o desastre, mas desperdiça a estação.",
+          "covenantThreat": "Seu experimento sai pela culatra de tal forma que todo o concílio fica ameaçado, seja pelo fogo, pela convocação de uma grande ameaça ou por alguma outra calamidade inventada pelo narrador da história.",
+          "destroyedCreation": "Sua criação está destruída.",
+          "destroyedCreationPlus": "Sua criação foi destruída, assim como algum outro item valioso que você mantém em seu laboratório.",
+          "explosion": "Explosão! Seu equipamento de laboratório está arruinado e você deve lançar um dado simples para cada bem valioso que mantém em seu laboratório. Com 0, ele é destruído. Você sofre uma quantidade de dano igual a um dado simples + o nível da magia ou efeito que você estava trabalhando.",
+          "rollTwice": "Role mais duas vezes neste gráfico.",
+          "warping": "Você ganha Pontos de Distorção igual ao número de zeros na jogada de falha crítica. Role para Crepúsculo se você ganhar dois ou mais"
+        },
+        "discovery": {
+          "ability": {
+            "long": "Você ganha 15 pontos de experiência em alguma Habilidade relacionada ao experimento.",
+            "short": "Inspiração de Habilidade."
+          },
+          "art": {
+            "long": "Você ganha três pontos de experiência em uma das Artes usadas no experimento",
+            "short": "Visão artística."
+          },
+          "artPlus": {
+            "long": "Você ganha pontos de experiência suficientes para levar uma das Artes usadas no experimento para o próximo nível (ou três pontos de experiência, o que for maior).",
+            "short": "Visão principal da arte."
+          },
+          "magicTheory": {
+            "long": "Você ganha 15 pontos de experiência em Teoria da Magia",
+            "short": "Inspiração de Teoria Mágica."
+          },
+          "rollTwice": {
+            "long": "Role duas vezes e role novamente este resultado se ele for gerado novamente",
+            "short": "Role duas vezes."
+          }
+        },
+        "extraordinaryResults": {
+          "disaster": {
+            "long": "Você falha miseravelmente. Consulte a tabela a seguir para obter o resultado, dependendo do número de zeros lançados nos dados com falha crítica. Sofra o efeito para o número que você rolar e para todos os números menores, a menos que seja explicitamente informado o contrário. Por exemplo, uma explosão (3) também destrói a criação e inflige Pontos de Distorção ao magus.",
+            "short": "Desastre"
+          },
+          "discovery": {
+            "long": "Jogue um dado simples e adicione seu modificador de risco. Se você estiver engajado na Descoberta Arcana (veja página @@), você faz uma descoberta que avança seu projeto e ignora esta tabela.",
+            "short": "Descoberta"
+          },
+          "failure": {
+            "long": "Você não ganha nada com seus esforços e sua estação é desperdiçada. Se você estava trabalhando em um item familiar ou encantado, jogue um dado simples. Com 0, ele é destruído.",
+            "short": "Falha completa"
+          },
+          "main": {
+            "short": "Resultados Extraordinários"
+          },
+          "modifiedEffect": {
+            "long": "Jogue um dado simples e adicione seu modificador de risco. Se você estava investigando um item mágico, você alterou um ou mais de seus poderes.",
+            "short": "Efeito modificado"
+          },
+          "noBenefit": {
+            "long": "Sua experimentação não produz resultados. Você perde o benefício do dado extra e do modificador de risco – recalcule seu Total de Lab. sem esses modificadores. Se o seu novo Total de Lab. for muito baixo para ter sucesso no projeto, ele deverá ser abandonado.",
+            "short": "Sem benefício"
+          },
+          "none": {
+            "long": "Seu experimento funciona sem produzir efeitos indesejados.",
+            "short": "Sem efeitos extraordinários"
+          },
+          "rollTwice": {
+            "long": "",
+            "short": "Role duas vezes nesta mesa."
+          },
+          "sideEffect": {
+            "long": "Sua criação mágica adquire um efeito colateral. Jogue um dado simples e resolva os detalhes com o narrador da história.",
+            "short": "Efeito colateral"
+          },
+          "special": {
+            "long": "O narrador de história escolhe um dos seguintes: <br><ul><li>A criação requer vis bruto adicional. O magus deve gastar um número adicional de peões de vis que corresponda à Técnica ou Forma do projeto igual à magnitude do efeito (incluindo modificações) mais o modificador de risco. Se ele não conseguir fazer isso, seja porque não tem vis, ou porque não consegue lidar com vis suficiente em uma única estação, trate como uma Falha Completa. </li><li>O magus também cria uma magia, com a mesma Técnica e Forma do projeto, de qualquer nível que ele poderia criar em uma única estação. O feitiço é elaborado pelo guia de história ou grupo e não precisa ter uma conexão óbvia com o projeto. O magus sabe disso e pode escrever o Texto do Laboratório normalmente, permitindo que outros magi o criem também. É mais simples se este feitiço seguir todas as regras da Magia Hermética, mas isso não é essencial se a trupe estiver satisfeita com as complicações. Trate isso como Sem Efeitos Extraordinários para o projeto principal.</li><li>A criação é modificada de alguma forma que não necessariamente se enquadra nas categorias de Efeito Colateral ou Efeito Modificado, embora possa, se desejado. Isso permite que o guia da história introduza qualquer tipo de efeito sobrenatural – a criação pode até ser fortemente afetada por um reino diferente. O resultado pode ser positivo ou negativo do ponto de vista do magus, mas deve ser interessante para a trupe.  Um evento de história acontece. Isso pode ser qualquer coisa; pode ser usado como uma oportunidade para apresentar um enredo importante ou como uma distração breve e divertida. Não precisa acontecer imediatamente; a magia descontrolada pode colocar algo em movimento ou pode ser o resultado do uso da criação em um contexto específico, algum tempo depois. O evento da história pode ser basicamente positivo — o magus pode atrair a atenção de um familiar em potencial, por exemplo. A menos que o evento da história exija o contrário, trate isso como Sem Efeitos Extraordinários para o projeto em si.</li></ul>",
+            "short": "Evento especial ou história"
+          }
+        },
+        "insight": "Descoberta bem sucedida! Agora você pode tentar estabilizar com um modificador de risco de {risk}",
+        "modifiedEffect": {
+          "changed": {
+            "long": "O efeito real do seu experimento é alterado completamente, exceto que a Técnica e a Forma relevantes permanecem inalteradas e o nível permanece semelhante",
+            "short": "Efeito alterado."
+          },
+          "increased": {
+            "long": "O alcance, duração, alvo ou potência do feitiço ou efeito é aumentado",
+            "short": "Efeito aumentado"
+          },
+          "modified": {
+            "long": "O efeito real da sua experiência é modificado. Por exemplo, um feitiço como Maldição de Circe (página 131) transforma o alvo em uma cabra em vez de um porco.",
+            "short": "Efeito modificado."
+          },
+          "reduced": {
+            "long": "O feitiço ou efeito é reduzido em alcance, duração, alvo ou potência",
+            "short": "Efeito reduzido."
+          },
+          "restricted": {
+            "long": "O uso da magia ou efeito é restrito. Por exemplo, não funciona em determinadas circunstâncias, como quando está chovendo",
+            "short": "Efeito restrito."
+          }
+        },
+        "report": {
+          "label": "Relatório de experimentação",
+          "tableRoll": "Rolado na tabela \"{tablename}\" com: <br/><div style=\"align-text:center\">{formula} = {total}</div>",
+          "tableRoll2": "Rolado na tabela \"{tablename}\"."
+        },
+        "riskModifier": "Modificador de risco",
+        "roll": "Role para experimentação",
+        "sideEffect": {
+          "fatalFlaw": {
+            "long": "O feitiço tem uma falha fatal. Por exemplo, um feitiço de invisibilidade faz você brilhar",
+            "short": "Falha mortal."
+          },
+          "majorFlaw": {
+            "long": "O feitiço tem uma grande falha. Por exemplo, um feitiço de cura causa grande dor em seus alvos.",
+            "short": "Falha grave."
+          },
+          "majorSideBenefit": {
+            "long": "O feitiço tem um grande benefício colateral. Por exemplo, um feitiço que transforma você em um lobo também permite que você fale com todas as feras enquanto for um lobo.",
+            "short": "Grande benefício colateral."
+          },
+          "majorSideEffect": {
+            "long": "O feitiço tem um efeito colateral importante. Por exemplo, um feitiço de controle de plantas atrai todos os pássaros em 100 passos.",
+            "short": "Efeito colateral importante."
+          },
+          "minorFlaw": {
+            "long": "O efeito tem uma pequena falha. Por exemplo, uma magia que permite que você se comunique com animais faz com que você retenha alguns dos padrões de fala do animal por um tempo após o término da magia.",
+            "short": "Falha menor."
+          },
+          "minorSideBenefit": {
+            "long": "O feitiço tem um pequeno benefício colateral. Por exemplo, um feitiço de vento tem um cheiro agradável e deixa os insetos voadores desconfortáveis",
+            "short": "Benefício colateral menor"
+          },
+          "minorSideEffect": {
+            "long": "O feitiço tem um efeito colateral menor. Por exemplo, uma magia que controla um animal faz com que a grama cresça sob seus pés.",
+            "short": "Efeito colateral menor."
+          },
+          "sigil": {
+            "long": "Sua insignia é exagerada muitas vezes a sua força normal, tornando-se uma parte significativa do efeito.",
+            "short": "Insignia exagerada."
+          }
+        },
+        "subject": "Assunto do experimento",
+        "title": "Experimentação Arcana"
+      }
     },
     "sanatorium": {
       "button": {
         "endRecovery": "Fim da recuperação",
         "endSeason": "Fim da estação",
-        "recovery": "Rolar para recuperação"
+        "fastRecovery": "Recuperação rápida (rolagem automática)",
+        "recovery": "Rolar para recuperação",
+        "rollSingle": "Rolar recuperação de ferimento"
       },
+      "dayOfSeason": "Dia da estação",
       "daysAvailbable": "Dias disponíveis",
       "daysLeft": "{days} dias restantes para próxima rolagem de recuperação",
-      "labHealth": "Ajuda Sanctum",
+      "labHealth": "Ajuda do Sanctum",
       "log": "Arquivo do Paciente",
       "magicalHelp": "Ajuda mágica",
       "medicalHistory": "Histórico médico",
       "msg": {
         "clearHistory": "Limpar histórico médico",
+        "incapDeath": "O paciente morre! (verificação de ferimento incapacitante falhada)",
+        "incapMustBeFirst": "Ferimentos incapacitantes devem ser tratados antes que ferimentos mais leves possam ser rolados individualmente.",
         "logDay": "Periodo de recuperação, dia {day}",
         "logDone": "Nada mais pode ser feito nesta estação.",
         "logHealed": "Ferimento completamente curado em {days} dia(s)",
@@ -860,16 +1077,39 @@
         "logWoundBetter": "Melhora de ferimento em {days} dia(s)",
         "logWoundStable": "Ferimento estabilizado",
         "logWoundWorse": "Ferimento piora em {days} dia(s)",
+        "nextSeason": "Avançando para {season} de {year}.",
+        "noWoundsForOverstrain": "Não há ferimentos ativos para aplicar um teste de esforço excessivo.",
+        "notOpen": "Abra a janela do Sanatório primeiro e depois role a partir daqui.",
+        "overstrainNote": "Agravado por sobrecarga em {season} {year}.",
+        "overstrainStable": "A ferida estabiliza – sem piora devido ao esforço excessivo.",
+        "overstrainWorsened": "{name} piorou para {type} devido ao esforço excessivo!",
         "patientDead": "O paciente está morto!",
         "patientDied": "O paciente morreu!",
-        "patientHealthy": "O paciente está saudável!"
+        "patientHealthy": "O paciente está saudável!",
+        "penaltyAdviceHeavy": "O personagem pode falar, comer e se mover por curtas distâncias com tempo e assistência. Atividades produtivas (incluindo estudo, trabalho no Laboratório Hermético e trabalho artesanal) são impossíveis.",
+        "penaltyAdviceLight": "O personagem pode viajar e estudar normalmente, mas não pode realizar atividades extenuantes, incluindo lançar magias que custem Fadiga. O trabalho de laboratório hermético e o trabalho artesanal podem ser realizados normalmente.",
+        "penaltyAdviceMedium": "O personagem pode andar, desde que possa andar devagar e descansar frequentemente. Todas as tarifas de viagens de longa distância foram reduzidas pela metade. O personagem pode estudar, mas seu Total de Avanço é reduzido à metade se ele permanecer neste nível de penalidade por um mês ou mais da estação. O trabalho hermético de laboratório e o trabalho artesanal são impossíveis.",
+        "sunriseRoll": "Nascer do sol",
+        "sunsetRoll": "Pôr do sol",
+        "worstPenaltyNote": "A penalidade de ferimento de {penalty} foi mantida por {days} dias nesta estação."
       },
       "mundaneHelp": "Ajuda mundana",
+      "overstrain": "Verificação de sobrecarga",
       "recoveryBonus": "Bônus de recuperação",
-      "viewMedicalHistory": "Ver histórico médico"
+      "viewMedicalHistory": "Ver histórico médico",
+      "woundRecovery": "Recuperação de feridas",
+      "woundsRecovery": "Recuperação de feridas"
     },
     "scriptorium": {
-      "button": "Criar atividade",
+      "button": {
+        "createActivity": "Criar atividade",
+        "selectBookToAppend": "Selecione um livro para anexar",
+        "selectBookToCopy": "Selecione um livro para copiar",
+        "selectBookToRead": "Selecione um livro para ler",
+        "selectReader": "Selecione o leitor",
+        "selectScribe": "Selecione o escriba",
+        "selectWriter": "Selecione o escritor"
+      },
       "copying": {
         "activity": "Copiando livro",
         "finalQuality": "Qualidade final",
@@ -898,9 +1138,12 @@
           "spell": "o aperfeiçoamento da magia \"{spell}\""
         },
         "dropBook": "Solte um livro aqui para preencher.",
+        "dropBookOrClick": "Deixe um livro aqui para preencher os espaços em branco ou clique para selecionar um de seus livros.",
         "dropBookTopic": "Solte um livro e selecione um tipo de tópico.",
         "dropCharacter": "Solte o personagem aqui.",
         "dropLabText": "Solte uma magia autoral ou rascunho de texto de lab.",
+        "emptyBook": "O livro está vazio, você não pode aprender nada com ele.",
+        "error": "Ocorreu um erro inesperado no Scriptorium. Verifique o console do navegador (F12) para mais detalhes.",
         "illiterate": "O leitor não sabe ler.",
         "invalidLevel": "Nível inválido.",
         "invalidQuality": "Quantidade inválida.",
@@ -918,10 +1161,9 @@
         "tractatusAlreadyRead": "O leitor já leu um Tractatus muito similar neste mesmo tópico com a mesma qualidade em \"{title}\"",
         "translationOnly": "Só é possível traduzir os próprios rascunhos do autor.",
         "unconfirmedLang": "Por favor, confirme se o escriba fala todas as línguas listadas.",
-        "unfamiliarTopic": "Tópico incomun ({topic}), qualquer cópica pode ser corrompida (Confirmar com narrador).",
+        "unfamiliarTopic": "Tópico incomun ({topic}), qualquer cóica pode ser corrompida (Confirmar com narrador).",
         "unfamiliarTopic2": "Confirme com o narrador se o escriba é talentoso o suficiente na habilidade relacionada.",
-        "whichItem": "Não conseguiu encontrar nenhum {item} conhecido pelo leitor. Selecione um se disponível.",
-        "error": "Ocorreu um erro inesperado no Scriptorium. Verifique o console do navegador (F12) para mais detalhes."
+        "whichItem": "Não conseguiu encontrar nenhum {item} conhecido pelo leitor. Selecione um se disponível."
       },
       "quickCopy": "Cópia rápida",
       "reader": {
@@ -940,6 +1182,8 @@
       },
       "writer": {
         "name": "Nome do escritor",
+        "noQualifyingArts": "O escritor não possui artes com nota 5 ou mais.",
+        "nothingToWrite": "O escritor não tem nada sobre o que escrever.",
         "title": "Escritor",
         "writingScoreLabel": "Pontuação do escritor (Com + Língua)",
         "writingScoreLabel2": "Nível de pontuação de tradução (Língua x 20)."
@@ -953,28 +1197,34 @@
       "abilities": "Habilidades",
       "ability": "Habilidade",
       "action": {
+        "Add": "Adicionar",
         "Create": "Criar",
         "Delete": "Deletar",
         "Edit": "Editar",
         "Filter": "Filtrar",
         "apply": "Aplicar",
         "invest": "Investir",
+        "partialProgress": "Progresso parcial",
         "reset": "Redefinir",
         "rest": "Descansar",
         "rollback": "Reverter",
         "update": "Atualizar"
       },
+      "actions": "Ações",
       "actuals": "Atual",
       "advanced": "Avançado",
       "advantage": "Vantagem",
       "aegisCovenant": "Aegis do Lar",
+      "aegisPenetration": "Penetração do Aegis",
       "aesthetics": "Estética",
       "aestheticsMax": "Estética máxima",
       "age": "Idade",
       "ageModifier": "Modificador de Idade",
       "aging": "Envelhecimento",
+      "agingMagi": "Envelhecimento para Magi",
+      "agingMundane": "Envelhecimento para Mundano",
       "agingPts": "Pontos de envelhecimento",
-      "agingStart": "Início de envelhecimento",
+      "agingStart": "Mod. de início de envelhecimento",
       "apparentAge": "Idade aparente",
       "apprentice": "Aprendiz",
       "apprenticeship": "Concílio de Aprendizado",
@@ -983,9 +1233,10 @@
       "art": "Arte",
       "arts": "Artes",
       "attack": "Ataque",
-      "attackAdvantage": "Vantagem Ataque",
+      "attackAdvantage": "Vantagem de Ataque",
       "attributes": "Atributos",
       "aura": "Aura",
+      "auraCfg": "Configuração da aura",
       "auraMod": "Modificador de aura",
       "authorship": {
         "author": "Autor",
@@ -1028,11 +1279,23 @@
       "child": "Criança",
       "com": "Com",
       "combat": {
-        "label": "Combate"
+        "defend": "Defender",
+        "flavor": {
+          "attack": "{attacker} ataca {target} com {weapon}.",
+          "damage": "{attacker} tenta infligir {amount} de dano.",
+          "damageWithTarget": "{attacker} tenta infligir {amount} de dano a {target}.",
+          "defense": "{defender} defende contra {attacker} com {weapon}.",
+          "defenseNoAttacker": "{defender} defende com {weapon}.",
+          "noWeapon": "sem arma",
+          "soak": "{target} absorve o dano."
+        },
+        "label": "Combate",
+        "preparation": "Preparação de combate",
+        "wound": "Ferimento de combate infligido por {attacker}"
       },
       "combatInstructions1": "Equipe armas e armaduras para ver o total.",
       "combatInstructions2": "Se sua especialidade for com o escudo, marque-a no escudo e não na arma. Se não tiver o escudo equipado, o bônus de especialidade não se aplica.",
-      "combatInstructions3": "Crie um item 'montado' com a habilidade 'montado' e marque em seus atributos que se trata de um cavalo. Quando você o equipar, o cálculo será aplicado.",
+      "combatInstructions3": "Crie um item 'montado' com a habilidade de montar e marque em seus atributos que se trata de um cavalo. Quando você o equipar, o cálculo será aplicado.",
       "communication": "Comunicação",
       "companion": "Companheiro",
       "companions": "Companheiros",
@@ -1078,6 +1341,9 @@
       "domusMagnus": "Domus Magna",
       "duration": "Duração",
       "economics": "Economia",
+      "edition": {
+        "creationMode": "Modo de criação"
+      },
       "effect": "Efeito",
       "effects": "Efeitos",
       "effectsToggle": "Ativar",
@@ -1098,7 +1364,11 @@
         "label": "Velocidade de Magia Acelerada"
       },
       "fatigue": {
-        "label": "Fadiga"
+        "add": "Adicione um nível de fadiga + SHIFT para longo prazo.",
+        "label": "Fadiga",
+        "overflow": "Estouro de fadiga",
+        "recover": "Recuperar um nível de fadiga + SHIFT para longo prazo.",
+        "roll": "Rolagem de fadiga"
       },
       "features": "Equipamentos",
       "fieldOfWork": "Área de Atuação",
@@ -1159,6 +1429,7 @@
       "initials": "Inicial",
       "initiations": "Iniciações",
       "initiative": "Iniciativa",
+      "initiativeShort": "Iniciar",
       "int": "Int",
       "intelligence": "Inteligência",
       "inventory": "Inventário",
@@ -1255,6 +1526,7 @@
       "modifiersLifeMagi": "Condição de Vida (Magi)",
       "modifiersLifeMundane": "Condição de Vida (Mundanos)",
       "money": "Dinheiro",
+      "mounted": "Montado",
       "multipleCasting": {
         "label": "Múltiplas Magias"
       },
@@ -1266,6 +1538,7 @@
       "narrator": "Narrador",
       "natRes": "Resistência natural",
       "nationality": "Raça/Nacionalidade",
+      "naturalweapon": "Arma natural",
       "naturalweapons": "Armas naturais",
       "noMagicResistance": "Sem resistência mágica",
       "none": "Nenhum",
@@ -1309,12 +1582,14 @@
       "possessions": "Possessões",
       "power": "Poder",
       "powerCost": "Potência {might} - 5 vezes o custo ({cost})",
+      "powerLevel": "5 vezes o custo ({res})",
       "powers": "Poderes",
       "pre": "Pre",
       "presence": "Presença",
       "priceless": "Inestimável",
       "primus": "Primus",
       "profession": "Título/Profissão",
+      "progress": "Progresso",
       "properties": "Propriedades e Terra",
       "protection": "Proteção",
       "provisions": "Provisões",
@@ -1330,12 +1605,15 @@
       "religion": "Religião",
       "reputation": "Reputação",
       "reputationType": {
+        "academic": "Acadêmico",
         "ecclesiastic": "Eclesiástica",
         "hermetic": "Hermética",
+        "infernal": "Infernal",
         "local": "Local",
         "persona": "Persona"
       },
       "ritual": "Ritual",
+      "rollFailed": "Falha na rolagem",
       "rooms": "Cômodos",
       "safety": "Segurança",
       "saga": "Saga",
@@ -1343,9 +1621,11 @@
       "salubrity": "Salubridade",
       "sanctum": "Sanctum",
       "saving": "Reduções",
+      "scene": "Cena",
       "score": "Pontuação",
       "season": "Estação",
       "seasons": "estações",
+      "secrets": "Segredos",
       "security": "Segurança",
       "servants": "Servos",
       "setAbilities": "Crie habilidades para seu personagem com os valores abaixo. Isso permitirá que o cálculo correto seja feito. Se você não tiver a habilidade, ainda poderá criá-la com um valor zero",
@@ -1363,12 +1643,22 @@
       "soakBonus": "Bônus de absorção",
       "soakRoll": "Rolagem de absorção",
       "socialStatus": "Classe Social",
+      "socialStatusEastern": "Status Social (Cristandade Oriental)",
+      "socialStatusHibernia": "Status Social (Hibéria)",
+      "socialStatusIberia": "Estatuto Social (Ibéria)",
+      "socialStatusIslamic": "Status social (islâmico)",
+      "socialStatusJewish": "Status social (judeu)",
+      "socialStatusNorthAfrica": "Estatuto Social (Norte de África)",
+      "socialStatusPersia": "Status social (Pérsia)",
+      "socialStatusProvencal": "Status social (provençal)",
+      "socialStatusWestern": "Status Social (Cristandade Ocidental)",
       "source": {
         "A&A": "Art & Academe",
         "AnM": "Ancient Magic",
         "Ant": "Antagonists",
         "App": "Apprentices",
         "ArM5": "Livro Base",
+        "ArM5Def": "Edição Definitiva Ars",
         "AtD": "Contra a Escuridão",
         "BCoC": "The Broken Cov. of Cabelais",
         "C&C": "The Cradle & The Crescent",
@@ -1389,6 +1679,7 @@
         "L&L": "The Lion and The Lily",
         "LH": "Legends of Hermes",
         "LoM": "Lord of Men",
+        "LotN": "Terras do Nilo",
         "ML": "Mythic Locations",
         "MoH": "Magi of Hermes",
         "RM": "Rival Magic",
@@ -1400,11 +1691,13 @@
         "TME": "Transforming Mythic Europe",
         "TMRE": "The Mysteries RE",
         "TSE": "The Sundered Eagle",
+        "TTT": "Contos contados três vezes",
         "ToME": "Tales of Mythic Europe",
         "ToP": "Tales of Power",
         "TtA": "Through the Aegis",
         "custom": "Homebrew",
-        "label": "Fonte"
+        "label": "Fonte",
+        "others": "Outro"
       },
       "sourceQuality": "Qualidade",
       "specialists": "Especialistas",
@@ -1428,6 +1721,9 @@
       "standard": "Padrão",
       "state": {
         "label": "Estado"
+      },
+      "states": {
+        "confidencePrompt": "Solicitação de determinação pendente"
       },
       "story": "Narrativo",
       "str": "For",
@@ -1468,6 +1764,7 @@
       "trainingRequired": "Treinamento Necessário",
       "tribunal": "Tribunal",
       "turbula": "Guardas",
+      "twilight": "Crepúsculo",
       "twilightScars": "Cicatriz do Crepúsculo",
       "type": "Tipo",
       "typeAura": "Tipo de Aura",
@@ -1505,6 +1802,7 @@
       "winded": "Ofegante",
       "windedLvl": "Nível Ofegante",
       "winter": "Inverno",
+      "withCompendium": "Incluir compêndios",
       "wound": {
         "fresh": "Tratamento não iniciado",
         "gravity": "Gravidade",
@@ -1624,7 +1922,8 @@
         "organization": "Nome da org.",
         "profession": "Nome da prof.",
         "supernatural": "Nome da habilidade",
-        "technique": "Nome da Técnica"
+        "technique": "Nome da Técnica",
+        "theology": "Religião"
       },
       "supernatural": {
         "animalKen": "Empatia com Animais",
@@ -1793,6 +2092,68 @@
       "maxYear": "Ano máximo",
       "minYear": "Ano mínimo",
       "troupeSchedule": "Calendário da trupe"
+    },
+    "twilight": {
+      "avoid": "Evitar",
+      "chat": {
+        "botchedControl": "Falha crítica no controle",
+        "botchedUnderstanding": "Falha crítica em entender",
+        "failedControl": "Falha no controle",
+        "failedUnderstanding": "Compreensão falhada",
+        "successControl": "Controle bem-sucedido",
+        "successUnderstanding": "Compreensão bem sucedida"
+      },
+      "complexity": "Role para a complexidade do crepúsculo",
+      "comprehension": {
+        "roll": "Tentativa de compreensão de Twilight"
+      },
+      "control": {
+        "avoid": "Evite Crepúsculo",
+        "question": "Você quer resistir a Crepúsculo?",
+        "roll": "Tentativa de controle de Twilight"
+      },
+      "diary": {
+        "botchedControl": "{name} falhou miseravelmente em controlar a onda de magia (força {str}) e ficou com uma grande dor de cabeça e alguma perda de memória.",
+        "duration": "Tempo gasto no Crepúsculo: {duration}",
+        "embraced": "{name} abraçou a onda de magia e entrou em Crepúsculo",
+        "failedControl": "{name} falhou em controlar a onda de magia (força {str}) e entrou em Crepúsculo",
+        "failedUnderstanding": "{name} não conseguiu compreender a experiência (complexidade: {complexity})",
+        "successControl": "{name} controlou com sucesso a onda de magia (força {str}) e evitou Crepúsculo",
+        "successUnderstanding": "{name} compreendeu a experiência (complexidade: {complexity})"
+      },
+      "durations": {
+        "day": "Um dia (24 horas)",
+        "decades": "{num} anos",
+        "diameter": "Diâmetro (2 min)",
+        "eternal": "Eterno: Crepúsculo Final",
+        "hours": "Duas horas",
+        "moments": "Momentos",
+        "moon": "Uma lua",
+        "season": "Uma estação",
+        "sevenYears": "Sete anos",
+        "sun": "Sol",
+        "year": "Um ano"
+      },
+      "embrace": "Abraçar",
+      "embraceTwilight": "Você quer abraçar o crepúsculo ou tentar evitá-lo?",
+      "episode": "Episódio Crepúsculo",
+      "notification": {
+        "GMOnly": "Apenas guia de história",
+        "continueWithDiary": "Diário aberto para tentar entender"
+      },
+      "reset": "Você deseja redefinir este episódio de Crepúsculo?",
+      "strength": "Role para obter força crepuscular",
+      "tooltips": {
+        "pendingComplexity": "Pendente na rolagem da complexidade de Crepúsculo (somente SG)",
+        "pendingControl": "Pendente na rolagem do controle de Crepúsculo",
+        "pendingStrength": "Teste de força de Crepúsculo pendente (somente SG)",
+        "pendingUnderstanding": "Aguardando a rolagem do entendimento de Crepúsculo",
+        "pendingUnderstanding2": "Pendente rolagem de compreensão de Crepúsculo via entrada no diário"
+      },
+      "vimModifier": "Modificador de pontuação Vim",
+      "warpingPoints": "Pontos de distorção ganhos",
+      "warpingScore": "Pontuação distorcida",
+      "warpingThreshold": "Limite de deformação"
     }
   }
 }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1599,6 +1599,18 @@ export class ArM5eActorSheet extends foundry.appv1.sheets.ActorSheet {
     // migrate actor
     html.find(".migrate").click((event) => this.actor.migrate());
 
+    html.find(".remove-creationMode").click(async (event) => {
+      event.preventDefault();
+      let confirmed = await getConfirmation(
+        "",
+        game.i18n.localize("arm5e.sheet.msg.creationModeRemoval"),
+        ArM5eActorSheet.getFlavor(this.actor.type)
+      );
+      if (confirmed) {
+        await this.actor.update({ "system.states.creationMode": false });
+      }
+    });
+
     html.find(".plan-reading").click(async (ev) => this._readBook(ev));
 
     html.find(".indexkey-edit").change((event) => this._slugifyIndexKey(event));

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -22,6 +22,7 @@ import Aura from "../helpers/aura.js";
 import { canBeEnchanted } from "../helpers/magic.js";
 import { ArM5eMagicSystem } from "./subsheets/magic-system.js";
 import { ArM5eItem } from "../item/item.js";
+import { VisExtractionActivity } from "../seasonal-activities/labActivity.js";
 
 /**
  * Extend the base Actor entity by defining a custom roll data structure which is ideal for the Simple system.
@@ -135,7 +136,11 @@ export class ArM5eActor extends Actor {
     // For characters
     this.system.bonuses.labActivities = {
       learnSpell: 0,
-      inventSpell: 0
+      inventSpell: 0,
+      longevityRitual: 0,
+      visExtraction: 0,
+      enchanting: 0,
+      itemInvestigation: 0
     };
 
     this.system.bonuses.arts = {

--- a/module/apps/scriptorium.js
+++ b/module/apps/scriptorium.js
@@ -500,7 +500,7 @@ export class Scriptorium extends HandlebarsApplicationMixin(ApplicationV2) {
     // For convenience
     context.topicIndex = topicIndex;
     const currentTopic = context.reading.book.system.topics[topicIndex];
-    if (currentTopic.type === "Summa" || currentTopic.level) {
+    if (currentTopic.type === "Summa" && currentTopic.level) {
       maxLevel = currentTopic.level;
     }
     context.reading.book.currentTopic = currentTopic;
@@ -711,7 +711,7 @@ export class Scriptorium extends HandlebarsApplicationMixin(ApplicationV2) {
     // WRITING section
     if (context.writing.writer?.id) {
       let maxLevel = 99;
-      if (newTopic.type === "Summa" || newTopic.level) {
+      if (newTopic.type === "Summa" && newTopic.level) {
         maxLevel = newTopic.level;
       }
       context.ui.canEditWriter = "readonly";

--- a/module/constants/activeEffectsTypes.js
+++ b/module/constants/activeEffectsTypes.js
@@ -1586,6 +1586,30 @@ export const ACTIVE_EFFECTS_TYPES = {
         key: "system.bonuses.labActivities.inventSpell",
         mode: CONST.ACTIVE_EFFECT_MODES.ADD,
         default: 1
+      },
+      longevityRitual: {
+        mnemonic: "arm5e.lab.activity.longevityRitual",
+        key: "system.bonuses.labActivities.longevityRitual",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      visExtraction: {
+        mnemonic: "arm5e.lab.activity.visExtraction",
+        key: "system.bonuses.labActivities.visExtraction",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      enchanting: {
+        mnemonic: "arm5e.lab.activity.enchanting",
+        key: "system.bonuses.labActivities.enchanting",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
+      },
+      investigateItem: {
+        mnemonic: "arm5e.lab.activity.itemInvestigation",
+        key: "system.bonuses.labActivities.itemInvestigation",
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        default: 1
       }
     }
   },

--- a/module/helpers/active-effects.js
+++ b/module/helpers/active-effects.js
@@ -227,16 +227,18 @@ export default class ArM5eActiveEffect extends ActiveEffect {
     );
 
     for (let e of filtered) {
+      const tmp = e.toObject();
       let idx = 0;
       let filteredChanges = [];
-      for (let ch of e.changes) {
-        if (e.flags.arm5e.subtype[idx] === subtype) {
+      for (let ch of tmp.changes) {
+        if (tmp.flags.arm5e.subtype[idx] === subtype) {
           log(false, ch);
           filteredChanges.push(ch);
         }
+        idx++;
       }
-      e.changes = filteredChanges;
-      res.push(e);
+      tmp.changes = filteredChanges;
+      res.push(tmp);
     }
 
     return res;

--- a/module/seasonal-activities/labActivity.js
+++ b/module/seasonal-activities/labActivity.js
@@ -109,6 +109,10 @@ export class LabActivity extends Activity {
     return "systems/arm5e/templates/lab-activities/noparams.html";
   }
 
+  ownerActivityModifier() {
+    return this.type;
+  }
+
   labActivitySpec(lab) {
     return { mod: 0, label: "" };
   }
@@ -248,7 +252,7 @@ export class LabActivity extends Activity {
     // Owner modifiers
     let effects = ArM5eActiveEffect.findAllActiveEffectsWithSubtypeFiltered(
       actor.effects,
-      this.type
+      this.ownerActivityModifier()
     );
 
     this.ownerActivityMod = 0;
@@ -812,6 +816,10 @@ export class MinorEnchantment extends LabActivity {
         "arm5e.lab.specialty.items"
       )} (${lab.system.specialty.items.bonus}) &#10`
     };
+  }
+
+  ownerActivityModifier() {
+    return "enchanting";
   }
 
   get activitySheet() {

--- a/module/tests/scriptoriumTests.js
+++ b/module/tests/scriptoriumTests.js
@@ -575,6 +575,56 @@ export function registerScriptoriumTesting(quench) {
             assert.ok(false, err.message);
           }
         });
+
+        it("SC.1.17: Summa with level = 0 sets invalidLevel error", async function () {
+          this.timeout(300000);
+          try {
+            // checkReading guards: level < 1 triggers invalidLevel, regardless of NaN
+            const ctx = makeReadingContext({ type: "Summa", level: 0 });
+            app.checkReading(ctx, magus);
+            assert.equal(ctx.ui.reading.error, true, "level 0 Summa should set error");
+            assert.ok(ctx.ui.reading.warning.length > 0, "invalidLevel warning should be pushed");
+          } catch (err) {
+            console.error(`SC.1.17 error: ${err}`);
+            assert.ok(false, err.message);
+          }
+        });
+
+        it("SC.1.18: Summa with level = -1 sets invalidLevel error", async function () {
+          this.timeout(300000);
+          try {
+            // Negative level is also < 1 and must be rejected.
+            const ctx = makeReadingContext({ type: "Summa", level: -1 });
+            app.checkReading(ctx, magus);
+            assert.equal(ctx.ui.reading.error, true, "negative level Summa should set error");
+          } catch (err) {
+            console.error(`SC.1.18 error: ${err}`);
+            assert.ok(false, err.message);
+          }
+        });
+
+        it("SC.1.19: supernatural ability (secondSight), reader has no matching ability → missingSupernatural error", async function () {
+          this.timeout(300000);
+          try {
+            // secondSight has category supernaturalCat.
+            // makeReadingContext sets reader.ability = "" so lookup returns undefined → !ab = true.
+            const ctx = makeReadingContext({
+              category: "ability",
+              type: "Tractatus",
+              key: "secondSight",
+              option: ""
+            });
+            app.checkReading(ctx, magus);
+            assert.equal(
+              ctx.ui.reading.error,
+              true,
+              "missing supernatural ability should set error"
+            );
+          } catch (err) {
+            console.error(`SC.1.19 error: ${err}`);
+            assert.ok(false, err.message);
+          }
+        });
       });
 
       // ======================================================================
@@ -723,6 +773,25 @@ export function registerScriptoriumTesting(quench) {
             );
           } catch (err) {
             console.error(`SC.1b.9 error: ${err}`);
+            assert.ok(false, err.message);
+          }
+        });
+
+        it("SC.1b.10: illiterate writer with no language pushes two independent warnings", async function () {
+          this.timeout(300000);
+          try {
+            // Both the illiteracy check and the language check run unconditionally.
+            // Verify they accumulate rather than short-circuit on the first failure.
+            const ctx = makeWritingContext({}, { writing: { writer: { languages: [] } } });
+            app.checkWriting(ctx, illiterate);
+            assert.equal(ctx.ui.writing.error, true, "should error");
+            assert.isAtLeast(
+              ctx.ui.writing.warning.length,
+              2,
+              "illiterate + noLanguage should push at least 2 warnings"
+            );
+          } catch (err) {
+            console.error(`SC.1b.10 error: ${err}`);
             assert.ok(false, err.message);
           }
         });
@@ -907,6 +976,43 @@ export function registerScriptoriumTesting(quench) {
             );
           } catch (err) {
             console.error(`SC.1c.9 error: ${err}`);
+            assert.ok(false, err.message);
+          }
+        });
+
+        it("SC.1c.10: mastery topic, scribe with magicTheory ≥ 1 → no unfamiliarTopic warning", async function () {
+          this.timeout(300000);
+          try {
+            // Magus has magicTheory score ≥ 1 → mastery branch should produce no warning.
+            const ctx = makeCopyingContext({ category: "mastery", languageConfirmed: true });
+            app.checkCopying(ctx, magus);
+            assert.equal(
+              ctx.ui.copying.warning.length,
+              0,
+              "mastery topic with magicTheory should produce no warnings"
+            );
+            assert.equal(ctx.ui.copying.error, false, "no error expected");
+          } catch (err) {
+            console.error(`SC.1c.10 error: ${err}`);
+            assert.ok(false, err.message);
+          }
+        });
+
+        it("SC.1c.11: illiterate scribe + mastery topic pushes both illiteracy and unfamiliarTopic warnings", async function () {
+          this.timeout(300000);
+          try {
+            // illiterate has artesLib score 0 (illiteracy warning) and no magicTheory
+            // (unfamiliarTopic warning for mastery). Both checks run unconditionally.
+            const ctx = makeCopyingContext({ category: "mastery", languageConfirmed: true });
+            app.checkCopying(ctx, illiterate);
+            assert.equal(ctx.ui.copying.error, true, "should error");
+            assert.isAtLeast(
+              ctx.ui.copying.warning.length,
+              2,
+              "illiterate + unfamiliarTopic (mastery) should push at least 2 warnings"
+            );
+          } catch (err) {
+            console.error(`SC.1c.11 error: ${err}`);
             assert.ok(false, err.message);
           }
         });
@@ -1441,6 +1547,38 @@ export function registerScriptoriumTesting(quench) {
             delete magus.apps[scriptApp.options.uniqueId];
           } catch (err) {
             console.error(`SC.6.5 error: ${err}`);
+            assert.ok(false, err.message);
+          } finally {
+            if (book) await book.delete();
+          }
+        });
+
+        it("SC.6.6 (regression || → &&): ability Tractatus with level=5, reader score=5 → NOT flagged tooSkilled", async function () {
+          this.timeout(300000);
+          // Before the fix (_prepareReadingContext used ||), a Tractatus topic with a truthy
+          // `level` would set maxLevel = level.  With artesLib score 5 and maxLevel 5,
+          // the ability was filtered from `filteredAbilities` (5 < 5 = false) and the reader
+          // was incorrectly flagged as tooSkilled.  After the fix (&&), only Summa topics
+          // cap maxLevel, so a Tractatus reader at score 5 is no longer erroneously blocked.
+          let book;
+          try {
+            book = await createBook(
+              { category: "ability", type: "Tractatus", key: "artesLib", level: 5, quality: 8 },
+              "SC.6.6 Regression Book"
+            );
+            const scriptApp = new Scriptorium(new ScriptoriumObject(), {});
+            await scriptApp._setReadingBook(book);
+            await scriptApp._setReader(magus); // magus has artesLib score 5
+            const ctx = await scriptApp._prepareContext({});
+            await scriptApp._preparePartContext("reading", ctx);
+            assert.equal(
+              ctx.ui.reading.error,
+              false,
+              "Tractatus with level field must not trigger tooSkilled (|| → && regression)"
+            );
+            delete magus.apps[scriptApp.options.uniqueId];
+          } catch (err) {
+            console.error(`SC.6.6 error: ${err}`);
             assert.ok(false, err.message);
           } finally {
             if (book) await book.delete();

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "arm5e",
   "title": "Ars Magica 5th Edition",
   "description": "Ars Magica 5e for Foundry VTT, mandatory arm5e-compendia module at (https://github.com/Xzotl42/arm5e-compendia/releases/latest/download/module.json)",
-  "version": "3.0.0.7",
+  "version": "3.0.0.8",
   "compatibility": {
     "minimum": "13.351",
     "verified": "13.351"

--- a/templates/actor/actor-pc-sheet.html
+++ b/templates/actor/actor-pc-sheet.html
@@ -12,9 +12,10 @@
               title="{{actor.name}}" placeholder="Name" />
 
             {{#if system.states.creationMode}}
-              <div class="flex0 padding10" style="width:36px"><img src="systems/arm5e/assets/icons/creation-mode.svg"
-                  title='{{localize "arm5e.sheet.edition.creationMode"}}'
-                  style="border: 0px; height: 18px; min-height:30px; min-width: 30px;">
+              <div class="flex0 padding10" style="width:36px"><a class="clickable remove-creationMode"><img
+                    src="systems/arm5e/assets/icons/creation-mode.svg"
+                    title='{{localize "arm5e.sheet.edition.creationMode"}}'
+                    style="border: 0px; height: 18px; min-height:30px; min-width: 30px;"></a>
 
               </div>
             {{/if}}

--- a/tools/expandLangFiles.cjs
+++ b/tools/expandLangFiles.cjs
@@ -1,0 +1,102 @@
+const fs = require("fs");
+const path = require("path");
+
+function getType(variable) {
+  const typeOf = typeof variable;
+  if (typeOf !== "object") return typeOf;
+  if (variable === null) return "null";
+  if (!variable.constructor) return "Object";
+  if (variable.constructor === Object) return "Object";
+  return "Unknown";
+}
+
+const SKIPPED_PROPERTIES = new Set(["__proto__", "constructor", "prototype"]);
+
+function setProperty(object, key, value) {
+  if (!key || SKIPPED_PROPERTIES.has(key)) return false;
+
+  let target = object;
+  if (key.includes(".")) {
+    const parts = key.split(".");
+    if (parts.some((p) => SKIPPED_PROPERTIES.has(p))) return false;
+
+    key = parts.pop();
+    target = parts.reduce((o, p) => {
+      if (!(p in o)) o[p] = {};
+      return o[p];
+    }, object);
+  }
+
+  if (!(key in target) || target[key] !== value) {
+    target[key] = value;
+    return true;
+  }
+
+  return false;
+}
+
+function expandObject(obj) {
+  const _expand = (value, depth) => {
+    if (depth > 32) throw new Error("Maximum object expansion depth exceeded");
+    if (!value) return value;
+    if (Array.isArray(value)) return value.map((v) => _expand(v, depth + 1));
+    if (getType(value) !== "Object") return value;
+
+    const expanded = {};
+    for (const [k, v] of Object.entries(value)) {
+      setProperty(expanded, k, _expand(v, depth + 1));
+    }
+    return expanded;
+  };
+
+  return _expand(obj, 0);
+}
+
+function sortProperties(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(sortProperties);
+  }
+
+  if (obj && typeof obj === "object" && obj.constructor === Object) {
+    return Object.keys(obj)
+      .sort()
+      .reduce((acc, key) => {
+        acc[key] = sortProperties(obj[key]);
+        return acc;
+      }, {});
+  }
+
+  return obj;
+}
+
+function processLanguageFile(langName, langDir) {
+  const filePath = path.join(langDir, `${langName}.json`);
+  const backupPath = path.join(langDir, `${langName}.json.bak`);
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`Language file not found: ${filePath}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  fs.copyFileSync(filePath, backupPath);
+  console.log(`Backup created at ${backupPath}`);
+
+  const json = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const expanded = expandObject(json);
+  const sorted = sortProperties(expanded);
+
+  fs.writeFileSync(filePath, JSON.stringify(sorted, null, 2), "utf8");
+  console.log(`Processed and expanded ${langName}.json`);
+}
+
+const lang = process.argv[2] || "all";
+const langDirArg = process.argv[3] || "..\\lang";
+const langDir = path.isAbsolute(langDirArg) ? langDirArg : path.resolve(__dirname, langDirArg);
+
+if (lang === "all") {
+  const files = fs.readdirSync(langDir).filter((f) => f.endsWith(".json"));
+  files.forEach((file) => processLanguageFile(path.basename(file, ".json"), langDir));
+} else {
+  processLanguageFile(lang, langDir);
+}


### PR DESCRIPTION
## Changes

- New active effects
  - Vis extraction activity modifier
  - Enchanting activity modifier
  - Item investigation modifier
  - Longevity Rituals modifier
- It will be possible for players to disable creation mode by clicking on the icon
- Updated translations:
  - French by @Orneen
  - Brazilian Portuguese by @Gapherd
  
  ## Fixes
  
  - [Scriptorium]
  - Dropping an empty book no longer raises an error and close the Scriptorium
  - When the writer has no qualifying abilities, warnings were pushed to the reading tab so the Writing tab never showed an error.
  - Copying Ability summae takes now the proper time.
  - Maximum level is not computed properly with Tractati in the Scriptorium