### PR TITLE
Fix/crfaftsmen linkage and display issues

### DIFF
--- a/module/arm5e.js
+++ b/module/arm5e.js
@@ -297,6 +297,9 @@ Hooks.once("ready", async function () {
     void syncLinkedInhabitantsForActor(item.parent);
   });
   Hooks.on("updateItem", (item) => {
+    if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
+      item.parent.sheet?.render(false);
+    }
     if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
     void syncLinkedInhabitantsForActor(item.parent);
   });

--- a/module/sheets/item/item-inhabitant-sheet-v2.js
+++ b/module/sheets/item/item-inhabitant-sheet-v2.js
@@ -102,11 +102,11 @@ export class ArM5eInhabitantItemSheetV2 extends ArM5eItemSheetV2 {
       }
     }
 
-    if (sys.category === "craftsmen" && sys.linked) {
-      const linkedActor = game.actors.get(sys.actorId);
+    if (sys.category === "craftsmen") {
       context.craftSyncAbilities = {
         "": game.i18n.localize("arm5e.sheet.none")
       };
+      const linkedActor = sys.linked ? game.actors.get(sys.actorId) : null;
       if (linkedActor) {
         for (const ability of linkedActor.items.filter((item) => item.type === "ability")) {
           const score = ability.system?.finalScore ?? ability.system?.score ?? 0;

--- a/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
+++ b/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
@@ -282,7 +282,7 @@
         <div class="item-image item-control item-edit" data-action="itemEdit"><img src="{{item.img}}" title="{{item.name}}" /></div>
         <div class="flexrow flex-center">
           <span class="flexrow item-title width15">{{item.name}}</span>
-          <span class="flexrow bold width15">{{item.system.job}}{{#if (eq item.system.specialistType "other")}} ({{item.system.score}}){{/if}}</span>
+          <span class="flexrow bold width15">{{item.system.job}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}: {{item.system.yearBorn}} </span>
           <span class="flexrow bold flex05">{{localize "arm5e.sheet.loyalty"}}: {{item.system.loyalty}}
           </span>
@@ -322,16 +322,19 @@
         <div class="item-image item-control item-edit" data-action="itemEdit"><img src="{{item.img}}" title="{{item.name}}" /></div>
         <div class="flexrow flex-center">
           <span class="flexrow item-title width15">{{item.name}}</span>
-          <span class="flexrow bold width15">{{item.system.job}} ({{item.system.score}})</span>
-          <span class="flexrow bold">{{localize "arm5e.sheet.fieldOfWork"}}: 
-            {{localize (lookup config.covenant.fieldOfWork item.system.fieldOfWork)}}
-          </span>
+          <span class="flexrow bold width15">{{localize "arm5e.sheet.job"}}: {{item.system.job}}</span>
           <span class="flexrow bold flex05">Qty: {{item.system.quantity}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}: {{item.system.yearBorn}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.loyalty"}}: {{item.system.loyalty}}</span>
           {{#if item.system.isSpecialist}}<span class="flexrow badge">{{localize "arm5e.sheet.specialist"}}</span>{{/if}}
         </div>
         <div class="item-controls">
+          {{#if (eq item.system.linked true)}}
+            <a class="item-control actor-link" data-action="openLinkedActor" title="Linked to character" data-actorid="{{item.system.actorId}}"><i
+                class="fas fa-link fa-sm"></i></a>
+          {{else}}
+            <a title="Not linked to character"><i class="fas fa-unlink fa-sm"></i></a>
+          {{/if}}
           <a class="item-control item-edit" data-action="itemEdit" title="Edit Craftsperson"><i class="ars-Icon_Edit"></i></a>
           <a class="item-control actor-link-delete" data-action="removeLinkedItem" title="Delete Craftsperson"><i
               class="ars-Icon_Delete_Hand_Gesture"></i></a>

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -80,18 +80,6 @@
           <label class="bold">{{localize 'arm5e.sheet.job'}}</label>
           <input type="text" name="system.job" value="{{ system.job }}" data-dtype="String" />
         </div>
-        {{#if (eq system.specialistType 'other')}}
-        <div class="resource flexcol flex0">
-          <label class="bold">{{localize 'arm5e.sheet.score'}}</label>
-          <input
-            class="select-on-focus"
-            type="number"
-            name="system.score"
-            value="{{ system.score }}"
-            data-dtype="Number"
-          />
-        </div>
-        {{/if}}
       </div>
       {{#if ui.details}}
       <div class="flexrow">


### PR DESCRIPTION
Fixes a bug where unlinked craftsmen couldn't have their inhabitant sheet opened. Cleans up some minor inhabitant displays. Links inhabitant responsibilities to responsibilities display on covenant sheet.