### PR TITLE
Fix/optimize inhabitant updates

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1724,6 +1724,7 @@
         "others": "Other"
       },
       "sourceQuality": "Source quality",
+      "rare": "Rare",
       "specialist": "Specialist",
       "specialists": "Specialists",
       "specialistsSumary": "Ability pounds per year",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1705,6 +1705,7 @@
         "others": "Otro"
       },
       "sourceQuality": "Calidad de la fuente",
+      "rare": "Raro",
       "specialist": "Especialista",
       "specialists": "Especialistas",
       "specialistsSumary": "Libras de capacidad por año",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1676,6 +1676,7 @@
         "others": "Autre"
       },
       "sourceQuality": "Qualité de la Source",
+      "rare": "Rare",
       "specialist": "Spécialiste",
       "specialists": "Spécialistes",
       "specialistsSumary": "(Compétence) livres par saison",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1035,6 +1035,7 @@
         "label": "Fonte"
       },
       "sourceQuality": "Qualità della fonte",
+      "rare": "Raro",
       "specialist": "Specialista",
       "specialists": "Specialisti",
       "specialities": "Specialtà",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1700,6 +1700,7 @@
         "others": "Outro"
       },
       "sourceQuality": "Qualidade",
+      "rare": "Raro",
       "specialist": "Especialista",
       "specialists": "Especialistas",
       "specialistsSumary": "Habilidade libras por ano",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -248,6 +248,7 @@
       "soak": "Absorver",
       "socialStatus": "Status social",
       "source": "Fonte",
+      "rare": "Raro",
       "specialist": "Especialista",
       "specialists": "Especialistas",
       "specialities": "Especialidades",

--- a/module/arm5e.js
+++ b/module/arm5e.js
@@ -42,33 +42,12 @@ import {
   buildDuplicateAllowedTypes
 } from "./seasonal-activities/activity-config.js";
 import { registerActivityRollActions } from "./seasonal-activities/activity-roll-registrations.js";
-import { InhabitantSchema } from "./schemas/inhabitantSchema.js";
-
-async function syncLinkedInhabitantsForActor(actor) {
-  if (!actor || !["player", "npc", "beast"].includes(actor.type)) return;
-
-  const activeGM = game.users.activeGM;
-  if (activeGM && !activeGM.isSelf) return;
-
-  for (const covenant of game.actors.filter((candidate) => candidate.type === "covenant")) {
-    if (!covenant.isOwner) continue;
-
-    const updates = covenant.items
-      .filter((item) => item.type === "inhabitant" && item.system.actorId === actor.id)
-      .map((item) => {
-        const syncData = InhabitantSchema.getLinkedSyncData(item.system, actor);
-        const update = { _id: item.id, name: actor.name, img: actor.img };
-        for (const [key, value] of Object.entries(syncData)) {
-          update[`system.${key}`] = value;
-        }
-        return update;
-      });
-
-    if (updates.length) {
-      await covenant.updateEmbeddedDocuments("Item", updates, { render: true });
-    }
-  }
-}
+import {
+  hasLinkedInhabitantActorIdChange,
+  hasRelevantLinkedInhabitantActorChange,
+  invalidateLinkedInhabitantIndex,
+  requestLinkedInhabitantSync
+} from "./tools/inhabitant-sync.js";
 
 // Ensure system config exists before any early hooks (e.g. i18nInit) mutate CONFIG.ARM5E.
 CONFIG.ARM5E ??= ARM5E;
@@ -289,23 +268,36 @@ Hooks.once("ready", async function () {
   Hooks.on("dropActorSheetData", (actor, sheet, data) => onDropActorSheetData(actor, sheet, data));
   // Hooks.on("dropCanvasData", async (canvas, data) => onDropOnCanvas(canvas, data));
 
-  Hooks.on("updateActor", (actor) => {
-    void syncLinkedInhabitantsForActor(actor);
+  Hooks.on("createActor", (actor) => {
+    if (actor.type === "covenant") invalidateLinkedInhabitantIndex();
+  });
+  Hooks.on("updateActor", (actor, changes) => {
+    if (hasRelevantLinkedInhabitantActorChange(changes)) requestLinkedInhabitantSync(actor);
+  });
+  Hooks.on("deleteActor", (actor) => {
+    if (actor.type === "covenant") invalidateLinkedInhabitantIndex();
   });
   Hooks.on("createItem", (item) => {
-    if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
-    void syncLinkedInhabitantsForActor(item.parent);
-  });
-  Hooks.on("updateItem", (item) => {
     if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
-      item.parent.sheet?.render(false);
+      invalidateLinkedInhabitantIndex();
     }
     if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
-    void syncLinkedInhabitantsForActor(item.parent);
+    requestLinkedInhabitantSync(item.parent);
+  });
+  Hooks.on("updateItem", (item, changes, options) => {
+    if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
+      if (hasLinkedInhabitantActorIdChange(changes)) invalidateLinkedInhabitantIndex();
+      if (!options?.arm5eLinkedInhabitantSync) item.parent.sheet?.render(false);
+    }
+    if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
+    requestLinkedInhabitantSync(item.parent);
   });
   Hooks.on("deleteItem", (item) => {
+    if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
+      invalidateLinkedInhabitantIndex();
+    }
     if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
-    void syncLinkedInhabitantsForActor(item.parent);
+    requestLinkedInhabitantSync(item.parent);
   });
 
   if (game.user.isGM) {

--- a/module/schemas/inhabitantSchema.js
+++ b/module/schemas/inhabitantSchema.js
@@ -100,7 +100,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
         initial: 0,
         step: 1
       }),
-      isSpecialist: new fields.BooleanField({
+      isRare: new fields.BooleanField({
         required: false,
         nullable: false,
         initial: false
@@ -351,7 +351,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
   get craftSavings() {
     switch (this.category) {
       case "craftsmen":
-        if (this.isSpecialist) {
+        if (this.isRare) {
           return this.score;
         }
         else {
@@ -449,8 +449,14 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
     // Migrate "other" specialists to specialist craftspeople
     if (data.system.category === "specialists" && data.system.specialistType === "other" && data.system.fieldOfWork !== "none") {
       updateData["system.category"] = "craftsmen";
-      updateData["system.isSpecialist"] = true;
+      updateData["system.isRare"] = true;
       // fieldOfWork is already set, so it carries over
+    }
+    if (typeof data.system.isSpecialist === "boolean") {
+      if (typeof data.system.isRare !== "boolean" && updateData["system.isRare"] === undefined) {
+        updateData["system.isRare"] = data.system.isSpecialist;
+      }
+      updateData["system.-=isSpecialist"] = null;
     }
     if (typeof data.system.loyalty !== "number") {
       updateData["system.loyalty"] = convertToNumber(data.system.loyalty, 0);

--- a/module/tools/inhabitant-sync.js
+++ b/module/tools/inhabitant-sync.js
@@ -1,0 +1,145 @@
+import { InhabitantSchema } from "../schemas/inhabitantSchema.js";
+
+const SOURCE_ACTOR_TYPES = new Set(["player", "npc", "beast"]);
+const RELEVANT_ACTOR_PATHS = [
+  "name",
+  "img",
+  "system.description.born.value",
+  "system.characteristics.com.value",
+  "system.characteristics.pre.value"
+];
+
+let linkedInhabitants = new Map();
+let indexIsDirty = true;
+const pendingActorIds = new Set();
+let drainScheduled = false;
+let drainRunning = false;
+
+function rebuildIndex() {
+  const nextIndex = new Map();
+
+  for (const covenant of game.actors.filter((actor) => actor.type === "covenant")) {
+    for (const item of covenant.items) {
+      if (item.type !== "inhabitant" || !item.system.actorId) continue;
+      const links = nextIndex.get(item.system.actorId) ?? [];
+      links.push({ covenantId: covenant.id, itemId: item.id });
+      nextIndex.set(item.system.actorId, links);
+    }
+  }
+
+  linkedInhabitants = nextIndex;
+  indexIsDirty = false;
+}
+
+function buildChangedUpdate(item, actor) {
+  const desired = {
+    name: actor.name,
+    img: actor.img,
+    ...Object.fromEntries(
+      Object.entries(InhabitantSchema.getLinkedSyncData(item.system, actor)).map(([key, value]) => [
+        `system.${key}`,
+        value
+      ])
+    )
+  };
+  const update = { _id: item.id };
+
+  for (const [path, value] of Object.entries(desired)) {
+    const current = foundry.utils.getProperty(item, path);
+    if (!Object.is(current, value)) update[path] = value;
+  }
+
+  return Object.keys(update).length > 1 ? update : null;
+}
+
+async function syncActor(actor) {
+  if (!actor || !SOURCE_ACTOR_TYPES.has(actor.type)) return;
+
+  const activeGM = game.users.activeGM;
+  if (activeGM && !activeGM.isSelf) return;
+
+  if (indexIsDirty) rebuildIndex();
+  const links = linkedInhabitants.get(actor.id);
+  if (!links?.length) return;
+
+  const updatesByCovenant = new Map();
+  for (const { covenantId, itemId } of links) {
+    const covenant = game.actors.get(covenantId);
+    if (!covenant?.isOwner) continue;
+
+    const item = covenant.items.get(itemId);
+    if (!item || item.type !== "inhabitant" || item.system.actorId !== actor.id) {
+      indexIsDirty = true;
+      continue;
+    }
+
+    const update = buildChangedUpdate(item, actor);
+    if (!update) continue;
+    const updates = updatesByCovenant.get(covenant) ?? [];
+    updates.push(update);
+    updatesByCovenant.set(covenant, updates);
+  }
+
+  for (const [covenant, updates] of updatesByCovenant) {
+    await covenant.updateEmbeddedDocuments("Item", updates, {
+      render: false,
+      arm5eLinkedInhabitantSync: true
+    });
+    covenant.sheet?.render(false);
+  }
+}
+
+async function drainQueue() {
+  if (drainRunning) return;
+  drainScheduled = false;
+  drainRunning = true;
+
+  try {
+    while (pendingActorIds.size) {
+      const actorIds = [...pendingActorIds];
+      pendingActorIds.clear();
+      for (const actorId of actorIds) {
+        try {
+          await syncActor(game.actors.get(actorId));
+        } catch (error) {
+          console.error("ArM5e | Failed to synchronize linked covenant inhabitants", error);
+        }
+      }
+    }
+  } finally {
+    drainRunning = false;
+    if (pendingActorIds.size) scheduleDrain();
+  }
+}
+
+function scheduleDrain() {
+  if (drainScheduled || drainRunning) return;
+  drainScheduled = true;
+  queueMicrotask(() => void drainQueue());
+}
+
+export function requestLinkedInhabitantSync(actor) {
+  if (!actor || !SOURCE_ACTOR_TYPES.has(actor.type)) return;
+  pendingActorIds.add(actor.id);
+  scheduleDrain();
+}
+
+export function invalidateLinkedInhabitantIndex() {
+  indexIsDirty = true;
+}
+
+function hasChangeAtPath(changes, path) {
+  const changedPaths = Object.keys(foundry.utils.flattenObject(changes));
+  return changedPaths.some(
+    (changedPath) =>
+      changedPath === path || changedPath.startsWith(`${path}.`) || path.startsWith(`${changedPath}.`)
+  );
+}
+
+export function hasRelevantLinkedInhabitantActorChange(changes) {
+  return RELEVANT_ACTOR_PATHS.some((path) => hasChangeAtPath(changes, path));
+}
+
+export function hasLinkedInhabitantActorIdChange(changes) {
+  return hasChangeAtPath(changes, "system.actorId");
+}

--- a/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
+++ b/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
@@ -326,7 +326,7 @@
           <span class="flexrow bold flex05">Qty: {{item.system.quantity}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}: {{item.system.yearBorn}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.loyalty"}}: {{item.system.loyalty}}</span>
-          {{#if item.system.isSpecialist}}<span class="flexrow badge">{{localize "arm5e.sheet.specialist"}}</span>{{/if}}
+          {{#if item.system.isRare}}<span class="flexrow badge">{{localize "arm5e.sheet.rare"}}</span>{{/if}}
         </div>
         <div class="item-controls">
           {{#if (eq item.system.linked true)}}

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -124,7 +124,7 @@
         </div>
       </div>
 
-      {{!-- craftsmen: job, score, fieldOfWork, quantity, isSpecialist --}}
+      {{!-- craftsmen: job, score, fieldOfWork, quantity, isRare --}}
       {{else if (eq system.category 'craftsmen')}}
       <div class="flexrow">
         <div class="resource flexcol">
@@ -150,9 +150,9 @@
           </select>
         </div>
         <div class="resource flexcol flex0 flex-center">
-          <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
+          <label class="bold">{{localize 'arm5e.sheet.rare'}}</label>
           <div class="flexrow flex-group-center">
-            <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+            <input type="checkbox" name="system.isRare" {{checked system.isRare}} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Optimize Linked Covenant Inhabitant Synchronization

## Summary

Linked covenant inhabitants copy information from their source actors, including names, images, birth years, loyalty, and certain ability scores. Previously, every update to a player, NPC, or beast searched every covenant and every covenant item, then wrote every matching inhabitant back to Foundry even when its values had not changed.

This PR replaces that repeated work with an indexed, change-aware synchronization service. It preserves the existing synchronization rules while reducing world scans, database writes, and covenant sheet renders.

## Previous Behavior

Every actor update triggered the following process:

1. Search every actor in the world for covenants.
2. Search every item in each covenant for linked inhabitants.
3. Recalculate every matching inhabitant's synchronized fields.
4. Write every matching inhabitant back to Foundry.
5. Render covenant sheets as the embedded items update.

This happened for unrelated changes such as fatigue or other actor fields that cannot affect an inhabitant. Ability and personality-trait hooks could also request the same work several times during one operation.

## New Synchronization Service

The synchronization logic has moved from `module/arm5e.js` to `module/tools/inhabitant-sync.js`.

### 1. Actor-to-inhabitant index

The service builds an in-memory lookup table with the following relationship:

```text
Source actor ID -> linked covenant and inhabitant item IDs
```

After the index has been built, synchronizing one actor no longer requires searching every covenant and every item. The service can go directly to that actor's linked inhabitants.

The index is marked stale when:

- A covenant is created or deleted.
- A covenant inhabitant is created or deleted.
- An inhabitant's linked actor ID changes.

Marking the index stale is inexpensive. It is rebuilt only when the next synchronization actually needs it.

### 2. Relevant actor-change filtering

Actor updates request synchronization only when one of these fields may have changed:

- Name
- Image
- Birth year
- Communication
- Presence

Unrelated actor updates now stop at the hook and perform no covenant synchronization work.

Ability and personality-trait creation, updates, and deletion still request synchronization because they can affect loyalty, teaching, leadership, profession, or craftsman scores.

### 3. Request coalescing

Synchronization requests are collected in a small queue keyed by actor ID. If several hooks request synchronization for the same actor during one JavaScript operation, that actor appears only once in the queue.

For example, several related updates:

```text
Actor updated
Ability updated
Personality trait updated
```

can result in one synchronization pass instead of three.

Requests that arrive while synchronization is running are retained and processed afterward, so coalescing does not discard newer changes.

### 4. No-op update filtering

The existing `InhabitantSchema.getLinkedSyncData` method remains the source of truth for calculating linked values.

The service compares each calculated value with the value already stored on the inhabitant. An update payload contains only fields that actually changed. If all values are already correct, no database update is sent.

This preserves synchronization for:

- Actor name and image
- Birth year
- Loyalty
- Teacher Communication and Teaching scores
- Steward and chamberlain Presence and Profession scores
- Turb captain Presence and Leadership scores
- Linked craftsman ability scores

### 5. Batched writes and rendering

Changed inhabitants are grouped by covenant and sent through one embedded-document update per covenant.

Automatic rendering is disabled during that internal batch. Once the batch completes, the affected covenant sheet is rendered once. Normal manual inhabitant edits continue to render the covenant sheet as before.

The batch carries an internal `arm5eLinkedInhabitantSync` option so the standard item-update hook can distinguish synchronization updates from manual edits and avoid redundant renders.

## Hook Changes in `arm5e.js`

`module/arm5e.js` now contains lightweight hooks that delegate to the synchronization service:

- `createActor` and `deleteActor` invalidate the index for covenants.
- `updateActor` checks whether relevant actor fields changed before queueing synchronization.
- `createItem` invalidates the index for new inhabitants or queues their source actor for relevant character items.
- `updateItem` invalidates changed inhabitant links, avoids internal batch renders, and queues relevant character-item changes.
- `deleteItem` invalidates removed inhabitant links or queues synchronization after relevant character-item deletion.

The active-GM and covenant-ownership checks from the previous implementation remain in place. This prevents multiple clients from writing the same updates and prevents updates to covenants the current user cannot modify.

## Updated Data Flow

For a relevant change:

```text
Relevant actor or item value changes
             |
             v
Hook queues the source actor ID
             |
             v
Duplicate requests are coalesced
             |
             v
Index finds only that actor's linked inhabitants
             |
             v
Calculated values are compared with stored values
             |
             v
Only changed inhabitants are batched by covenant
             |
             v
Each affected covenant sheet renders once
```

For an unrelated actor change:

```text
Unrelated actor value changes
             |
             v
Hook finds no relevant changed field
             |
             v
No scan, database write, or covenant render
```

## Compatibility and Scope

- No document schema or persisted data changes are introduced.
- No migration is required.
- The index exists only in memory for the current Foundry session.
- Existing linked-value calculations remain in `InhabitantSchema`.
- Existing active-GM and ownership behavior is preserved.
- This is a performance refactor rather than a change to covenant relationship rules.

## Validation

- `node --check module/tools/inhabitant-sync.js`
- `node --check module/arm5e.js`
- `git diff --check`

All checks pass.
