### PR TITLE
Make companions able to be specialists

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1335,7 +1335,7 @@
       "covenantResources": "Covenant: Resources",
       "covenantSite": "Covenant: Site",
       "covenantSurroundings": "Covenant: Surroundings",
-      "craftsmen": "Craftsmen",
+      "craftsmen": "Craftspeople",
       "craftsmenSumary": "1 + (Ability / 2) pounds per year",
       "creator": "Creator",
       "cun": "Cun",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1336,6 +1336,7 @@
       "covenantSite": "Covenant: Site",
       "covenantSurroundings": "Covenant: Surroundings",
       "craftsmen": "Craftspeople",
+      "craftsperson": "Craftsperson",
       "craftsmenSumary": "1 + (Ability / 2) pounds per year",
       "creator": "Creator",
       "cun": "Cun",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1724,6 +1724,7 @@
         "others": "Other"
       },
       "sourceQuality": "Source quality",
+      "rare": "Rare",
       "specialist": "Specialist",
       "specialists": "Specialists",
       "specialistsSumary": "Ability pounds per year",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1705,6 +1705,7 @@
         "others": "Otro"
       },
       "sourceQuality": "Calidad de la fuente",
+      "rare": "Raro",
       "specialist": "Especialista",
       "specialists": "Especialistas",
       "specialistsSumary": "Libras de capacidad por año",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1318,6 +1318,7 @@
       "covenantSite": "Alianza: Localización",
       "covenantSurroundings": "Alianza: Entorno",
       "craftsmen": "Artesanos",
+      "craftsperson": "Artesano",
       "craftsmenCommonSumary": "1 + (Hab./2) libras por estación",
       "craftsmenRareSumary": "(Hab.) libras por estación",
       "craftsmenSumary": "1 + (Habilidad / 2) libras por año",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1676,6 +1676,7 @@
         "others": "Autre"
       },
       "sourceQuality": "Qualité de la Source",
+      "rare": "Rare",
       "specialist": "Spécialiste",
       "specialists": "Spécialistes",
       "specialistsSumary": "(Compétence) livres par saison",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1291,6 +1291,7 @@
       "covenantSite": "Alliance: Site",
       "covenantSurroundings": "Alliance: Alentours",
       "craftsmen": "Artisans",
+      "craftsperson": "Artisan",
       "craftsmenSumary": "[1 + (Compétence / 2)] livres par saison",
       "creator": "Créateur",
       "cun": "Rus",

--- a/lang/it.json
+++ b/lang/it.json
@@ -704,6 +704,7 @@
       "covenantSite": "Congrega: Sito",
       "covenantSurroundings": "Congrega: Dintorni",
       "craftsmen": "Artigiani",
+      "craftsperson": "Artigiano",
       "craftsmenCommonSumary": "1 + (Abilità / 2) soldi per stagione",
       "craftsmenRareSumary": "Abilità soldi per stagione",
       "creator": "Creatore",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1035,6 +1035,7 @@
         "label": "Fonte"
       },
       "sourceQuality": "Qualità della fonte",
+      "rare": "Raro",
       "specialist": "Specialista",
       "specialists": "Specialisti",
       "specialities": "Specialtà",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1315,6 +1315,7 @@
       "covenantSite": "Concílio: Local",
       "covenantSurroundings": "Concílio: Arredores",
       "craftsmen": "Artesões",
+      "craftsperson": "Artesão",
       "craftsmenSumary": "1 + (Habilidade / 2) libras p/ ano",
       "creator": "Criador",
       "cun": "Ins",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1700,6 +1700,7 @@
         "others": "Outro"
       },
       "sourceQuality": "Qualidade",
+      "rare": "Raro",
       "specialist": "Especialista",
       "specialists": "Especialistas",
       "specialistsSumary": "Habilidade libras por ano",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -248,6 +248,7 @@
       "soak": "Absorver",
       "socialStatus": "Status social",
       "source": "Fonte",
+      "rare": "Raro",
       "specialist": "Especialista",
       "specialists": "Especialistas",
       "specialities": "Especialidades",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -58,6 +58,7 @@
       "cost": "Custo",
       "costSavings": "Poupança de custos",
       "costsSavings": "Poupança de custos",
+      "craftsperson": "Artesão",
       "craftsmenCommon": "Artesãos (comum)",
       "craftsmenCommonSumary": "1 + (habilidade / 2) libras por temporada",
       "craftsmenRare": "Artesãos (raro)",

--- a/module/arm5e.js
+++ b/module/arm5e.js
@@ -42,33 +42,12 @@ import {
   buildDuplicateAllowedTypes
 } from "./seasonal-activities/activity-config.js";
 import { registerActivityRollActions } from "./seasonal-activities/activity-roll-registrations.js";
-import { InhabitantSchema } from "./schemas/inhabitantSchema.js";
-
-async function syncLinkedInhabitantsForActor(actor) {
-  if (!actor || !["player", "npc", "beast"].includes(actor.type)) return;
-
-  const activeGM = game.users.activeGM;
-  if (activeGM && !activeGM.isSelf) return;
-
-  for (const covenant of game.actors.filter((candidate) => candidate.type === "covenant")) {
-    if (!covenant.isOwner) continue;
-
-    const updates = covenant.items
-      .filter((item) => item.type === "inhabitant" && item.system.actorId === actor.id)
-      .map((item) => {
-        const syncData = InhabitantSchema.getLinkedSyncData(item.system, actor);
-        const update = { _id: item.id, name: actor.name, img: actor.img };
-        for (const [key, value] of Object.entries(syncData)) {
-          update[`system.${key}`] = value;
-        }
-        return update;
-      });
-
-    if (updates.length) {
-      await covenant.updateEmbeddedDocuments("Item", updates, { render: true });
-    }
-  }
-}
+import {
+  hasLinkedInhabitantActorIdChange,
+  hasRelevantLinkedInhabitantActorChange,
+  invalidateLinkedInhabitantIndex,
+  requestLinkedInhabitantSync
+} from "./tools/inhabitant-sync.js";
 
 // Ensure system config exists before any early hooks (e.g. i18nInit) mutate CONFIG.ARM5E.
 CONFIG.ARM5E ??= ARM5E;
@@ -289,23 +268,36 @@ Hooks.once("ready", async function () {
   Hooks.on("dropActorSheetData", (actor, sheet, data) => onDropActorSheetData(actor, sheet, data));
   // Hooks.on("dropCanvasData", async (canvas, data) => onDropOnCanvas(canvas, data));
 
-  Hooks.on("updateActor", (actor) => {
-    void syncLinkedInhabitantsForActor(actor);
+  Hooks.on("createActor", (actor) => {
+    if (actor.type === "covenant") invalidateLinkedInhabitantIndex();
+  });
+  Hooks.on("updateActor", (actor, changes) => {
+    if (hasRelevantLinkedInhabitantActorChange(changes)) requestLinkedInhabitantSync(actor);
+  });
+  Hooks.on("deleteActor", (actor) => {
+    if (actor.type === "covenant") invalidateLinkedInhabitantIndex();
   });
   Hooks.on("createItem", (item) => {
-    if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
-    void syncLinkedInhabitantsForActor(item.parent);
-  });
-  Hooks.on("updateItem", (item) => {
     if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
-      item.parent.sheet?.render(false);
+      invalidateLinkedInhabitantIndex();
     }
     if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
-    void syncLinkedInhabitantsForActor(item.parent);
+    requestLinkedInhabitantSync(item.parent);
+  });
+  Hooks.on("updateItem", (item, changes, options) => {
+    if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
+      if (hasLinkedInhabitantActorIdChange(changes)) invalidateLinkedInhabitantIndex();
+      if (!options?.arm5eLinkedInhabitantSync) item.parent.sheet?.render(false);
+    }
+    if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
+    requestLinkedInhabitantSync(item.parent);
   });
   Hooks.on("deleteItem", (item) => {
+    if (item?.type === "inhabitant" && item.parent?.type === "covenant") {
+      invalidateLinkedInhabitantIndex();
+    }
     if (!item?.parent || !["ability", "personalityTrait"].includes(item.type)) return;
-    void syncLinkedInhabitantsForActor(item.parent);
+    requestLinkedInhabitantSync(item.parent);
   });
 
   if (game.user.isGM) {

--- a/module/config.js
+++ b/module/config.js
@@ -1209,6 +1209,16 @@ ARM5E.covenant.specialists = {
   other: { label: "arm5e.covenant.specialist.other" }
 };
 
+ARM5E.covenant.companionRoles = {
+  none: { label: "arm5e.generic.none" },
+  teacher: { label: "arm5e.covenant.specialist.teacher" },
+  steward: { label: "arm5e.covenant.specialist.steward" },
+  chamberlain: { label: "arm5e.covenant.specialist.chamberlain" },
+  turbCaptain: { label: "arm5e.covenant.specialist.turbCaptain" },
+  craftsman: { label: "arm5e.sheet.craftsmen" },
+  other: { label: "arm5e.covenant.specialist.other" }
+};
+
 ARM5E.covenant.loyalty = {
   wages: {
     none: { factor: 0, label: "arm5e.covenant.wages.none", mod: -20 },

--- a/module/config.js
+++ b/module/config.js
@@ -1214,7 +1214,7 @@ ARM5E.covenant.companionRoles = {
   steward: { label: "arm5e.covenant.specialist.steward" },
   chamberlain: { label: "arm5e.covenant.specialist.chamberlain" },
   turbCaptain: { label: "arm5e.covenant.specialist.turbCaptain" },
-  craftsman: { label: "arm5e.sheet.craftsmen" },
+  craftsman: { label: "arm5e.sheet.craftsperson" },
   other: { label: "arm5e.covenant.specialist.other" }
 };
 

--- a/module/config.js
+++ b/module/config.js
@@ -1210,7 +1210,6 @@ ARM5E.covenant.specialists = {
 };
 
 ARM5E.covenant.companionRoles = {
-  none: { label: "arm5e.generic.none" },
   teacher: { label: "arm5e.covenant.specialist.teacher" },
   steward: { label: "arm5e.covenant.specialist.steward" },
   chamberlain: { label: "arm5e.covenant.specialist.chamberlain" },

--- a/module/schemas/covenantSchema.js
+++ b/module/schemas/covenantSchema.js
@@ -891,6 +891,25 @@ export class CovenantSchema extends foundry.abstract.TypeDataModel {
       }
     }
 
+
+    for (let companion of this.inhabitants.companion) {
+      if (companion.system.companionRole === "teacher") {
+        specialistPts += companion.system.buildPoints;
+      }
+    }
+    for (let companion of this.inhabitants.companion) {
+      if (companion.system.companionRole === "craftsman" && companion.system.fieldOfWork !== "none") {
+        let craft = slugify(companion.system.job, false);
+        let saves = companion.system.craftSavings;
+        if (!craftSavings[companion.system.fieldOfWork].crafts[craft]) {
+          craftSavings[companion.system.fieldOfWork].crafts[craft] = { val: saves, type: "craft" };
+        } else {
+          craftSavings[companion.system.fieldOfWork].crafts[craft].val += saves;
+        }
+        craftSavings[companion.system.fieldOfWork].total += saves;
+      }
+    }
+
     const activeEffects = this.parent.appliedEffects;
     this.yearlySavings.magicItems.quantity = ArM5eActiveEffect.findAllActiveEffectsWithTypeFiltered(
       activeEffects,

--- a/module/schemas/inhabitantSchema.js
+++ b/module/schemas/inhabitantSchema.js
@@ -31,7 +31,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
         required: false,
         blank: false,
         initial: "other",
-        choices: Object.keys(ARM5E.covenant.companionRoles)
+        choices: ["none", ...Object.keys(ARM5E.covenant.companionRoles)]
       }),
       loyalty: new fields.NumberField({
         required: false,
@@ -135,6 +135,146 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
     } else {
       this.linked = false;
     }
+  }
+
+  static getLinkedSyncData(inhabitant, actor) {
+    if (!actor) return {};
+
+    const syncData = {};
+    const yearBorn = convertToNumber(actor.system?.description?.born?.value, undefined);
+    if (yearBorn !== undefined) syncData.yearBorn = yearBorn;
+
+    const loyalty = InhabitantSchema.getLinkedLoyalty(actor);
+    if (loyalty !== undefined) syncData.loyalty = loyalty;
+
+    Object.assign(syncData, InhabitantSchema.getLinkedCompanionRoleSyncData(inhabitant, actor));
+    Object.assign(syncData, InhabitantSchema.getLinkedSpecialistSyncData(inhabitant, actor));
+    Object.assign(syncData, InhabitantSchema.getLinkedCraftsmanSyncData(inhabitant, actor));
+
+    return syncData;
+  }
+
+  static getLinkedLoyalty(actor) {
+    const loyaltyTrait = actor?.items?.find((item) => {
+      if (item.type !== "personalityTrait") return false;
+      const indexKey = item.system?.indexKey ?? "";
+      const name = (item.name ?? "").trim().toLowerCase();
+      return indexKey === "loyalty" || name === "loyalty";
+    });
+
+    if (!loyaltyTrait) return undefined;
+    if (typeof loyaltyTrait.system?.score === "number") return loyaltyTrait.system.score;
+    return PersonalityTraitSchema.getScore(loyaltyTrait.system?.xp ?? 0);
+  }
+
+  static getLinkedSpecialistSyncData(inhabitant, actor) {
+    if (inhabitant.category !== "specialists") return {};
+
+    switch (inhabitant.specialistType) {
+      case "teacher": {
+        const specialistChar = convertToNumber(actor.system?.characteristics?.com?.value, undefined);
+        const teacherScore = actor.getAbility?.("teaching")
+          ? actor.getAbilityStats("teaching")?.score
+          : undefined;
+        const syncData = {};
+        if (specialistChar !== undefined) syncData.specialistChar = specialistChar;
+        if (teacherScore !== undefined) syncData.teacherScore = teacherScore;
+        return syncData;
+      }
+      case "steward":
+      case "chamberlain": {
+        const specialistChar = convertToNumber(actor.system?.characteristics?.pre?.value, undefined);
+        const professionLabels = [
+          game.i18n.localize(`arm5e.covenant.specialist.${inhabitant.specialistType}`),
+          inhabitant.job,
+          inhabitant.specialistType,
+          inhabitant.specialistType.replace(/([A-Z])/g, " $1").trim()
+        ].filter((value) => typeof value === "string" && value !== "");
+        const profession = InhabitantSchema.getLinkedAbilityStats(actor, "profession", professionLabels);
+        const syncData = {};
+        if (specialistChar !== undefined) syncData.specialistChar = specialistChar;
+        if (profession !== undefined) syncData.score = profession.score;
+        return syncData;
+      }
+      case "turbCaptain": {
+        const specialistChar = convertToNumber(actor.system?.characteristics?.pre?.value, undefined);
+        const leadership = actor.getAbility?.("leadership")
+          ? actor.getAbilityStats("leadership")?.score
+          : undefined;
+        const syncData = {};
+        if (specialistChar !== undefined) syncData.specialistChar = specialistChar;
+        if (leadership !== undefined) syncData.score = leadership;
+        return syncData;
+      }
+      default:
+        return {};
+    }
+  }
+
+  static getLinkedCompanionRoleSyncData(inhabitant, actor) {
+    if (inhabitant.category !== "companions") return {};
+
+    switch (inhabitant.companionRole) {
+      case "teacher": {
+        const companionChar = convertToNumber(actor.system?.characteristics?.com?.value, undefined);
+        const teachingScore = actor.getAbility?.("teaching")
+          ? actor.getAbilityStats("teaching")?.score
+          : undefined;
+        const syncData = {};
+        if (companionChar !== undefined) syncData.specialistChar = companionChar;
+        if (teachingScore !== undefined) syncData.teacherScore = teachingScore;
+        return syncData;
+      }
+      case "steward":
+      case "chamberlain": {
+        const companionChar = convertToNumber(actor.system?.characteristics?.pre?.value, undefined);
+        const professionLabels = [
+          game.i18n.localize(`arm5e.covenant.specialist.${inhabitant.companionRole}`),
+          inhabitant.job,
+          inhabitant.companionRole,
+          inhabitant.companionRole.replace(/([A-Z])/g, " $1").trim()
+        ].filter((value) => typeof value === "string" && value !== "");
+        const profession = InhabitantSchema.getLinkedAbilityStats(actor, "profession", professionLabels);
+        const syncData = {};
+        if (companionChar !== undefined) syncData.specialistChar = companionChar;
+        if (profession !== undefined) syncData.score = profession.score;
+        return syncData;
+      }
+      case "turbCaptain": {
+        const companionChar = convertToNumber(actor.system?.characteristics?.pre?.value, undefined);
+        const leadership = actor.getAbility?.("leadership")
+          ? actor.getAbilityStats("leadership")?.score
+          : undefined;
+        const syncData = {};
+        if (companionChar !== undefined) syncData.specialistChar = companionChar;
+        if (leadership !== undefined) syncData.score = leadership;
+        return syncData;
+      }
+      default:
+        return {};
+    }
+  }
+
+  static getLinkedCraftsmanSyncData(inhabitant, actor) {
+    if (inhabitant.category !== "craftsmen" && !(inhabitant.category === "companions" && inhabitant.companionRole === "craftsman")) {
+      return {};
+    }
+    if (!inhabitant.syncAbilityId) return {};
+
+    const ability = actor.items?.get(inhabitant.syncAbilityId);
+    if (!ability) return {};
+
+    return {
+      score: ability.system?.finalScore ?? inhabitant.score
+    };
+  }
+
+  static getLinkedAbilityStats(actor, key, options = [""]) {
+    for (const option of options) {
+      const ability = actor.getAbility?.(key, option);
+      if (ability) return actor.getAbilityStats(key, option);
+    }
+    return undefined;
   }
 
   static getIcon(item, newValue = null) {

--- a/module/schemas/inhabitantSchema.js
+++ b/module/schemas/inhabitantSchema.js
@@ -27,6 +27,12 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
         blank: true,
         initial: null
       }),
+      companionRole: new fields.StringField({
+        required: false,
+        blank: false,
+        initial: "none",
+        choices: Object.keys(ARM5E.covenant.companionRoles)
+      }),
       loyalty: new fields.NumberField({
         required: false,
         nullable: false,
@@ -157,27 +163,53 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
     if (this.category === "specialists") {
       if (this.specialistType === "teacher") {
         return (this.specialistChar ?? 0) + (this.score ?? 0) + (this.teacherScore ?? 0);
-      } else {
-        return this.score ?? 0;
       }
+      return this.score ?? 0;
+    }
+    if (this.category === "companions" && this.companionRole === "teacher") {
+      return this.companionRoleChar + (this.score ?? 0) + this.companionTeacherScore;
     }
     return 0;
   }
 
   get loyaltyGain() {
-    if (this.category === "specialists") {
-      switch (this.specialistType) {
-        case "steward":
-        case "chamberlain":
-        case "turbCaptain": {
-          return (this.specialistChar ?? 0) + (this.score ?? 0);
-        }
-        default: {
-          return 0;
-        }
-      }
+    const role = this.category === "companions" ? this.companionRole : this.specialistType;
+    if (["steward", "chamberlain", "turbCaptain"].includes(role)) {
+      return this.roleChar + (this.score ?? 0);
     }
     return 0;
+  }
+
+  get roleChar() {
+    if (["steward", "chamberlain", "turbCaptain"].includes(this.companionRole)) {
+      if (this.linked && this.document?.system?.characteristics?.pre?.value !== undefined) {
+        return this.document.system.characteristics.pre.value;
+      }
+    }
+    return this.specialistChar ?? 0;
+  }
+
+  get companionRoleChar() {
+    if (this.companionRole === "teacher") {
+      if (this.linked && this.document?.system?.characteristics?.com?.value !== undefined) {
+        return this.document.system.characteristics.com.value;
+      }
+      return this.specialistChar ?? 0;
+    }
+    return this.roleChar;
+  }
+
+  get companionTeacherScore() {
+    if (this.companionRole === "teacher" && this.linked && this.document?.getAbilityStats) {
+      return this.document.getAbilityStats("teaching")?.score ?? this.teacherScore ?? 0;
+    }
+    return this.teacherScore ?? 0;
+  }
+
+  get covenantRole() {
+    if (this.category === "companions") return this.companionRole;
+    if (this.category === "specialists") return this.specialistType;
+    return "none";
   }
 
   /* -------------------------------------------- */
@@ -252,6 +284,11 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
     switch (this.category) {
       case "craftsmen":
         return Math.floor(1 + this.score / 2);
+      case "companions":
+        if (["craftsman", "craftsmen"].includes(this.companionRole)) {
+          return Math.floor(1 + this.score / 2);
+        }
+        return 0;
       case "specialists":
         if (this.specialistType === "other") {
           return this.score;

--- a/module/schemas/inhabitantSchema.js
+++ b/module/schemas/inhabitantSchema.js
@@ -30,7 +30,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
       companionRole: new fields.StringField({
         required: false,
         blank: false,
-        initial: "none",
+        initial: "other",
         choices: Object.keys(ARM5E.covenant.companionRoles)
       }),
       loyalty: new fields.NumberField({
@@ -123,6 +123,9 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
     if (this.document) {
       this.name = this.document.name;
       this.yearBorn = this.document.system.description.born.value;
+      if (this.category === "companions" && this.companionRole === "none") {
+        this.companionRole = "other";
+      }
       this.category = this.document.isMagus()
         ? "magi"
         : this.document.isCompanion()
@@ -209,7 +212,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
   get covenantRole() {
     if (this.category === "companions") return this.companionRole;
     if (this.category === "specialists") return this.specialistType;
-    return "none";
+    return "other";
   }
 
   /* -------------------------------------------- */
@@ -375,6 +378,9 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
 
     if (data.system.category === "grogs") {
       updateData["system.category"] = "turbula";
+    }
+    if (data.system.category === "companions" && data.system.companionRole === "none") {
+      updateData["system.companionRole"] = "other";
     }
     if (typeof data.system.loyalty !== "number") {
       updateData["system.loyalty"] = convertToNumber(data.system.loyalty, 0);

--- a/module/schemas/inhabitantSchema.js
+++ b/module/schemas/inhabitantSchema.js
@@ -231,7 +231,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
           : undefined;
         const syncData = {};
         if (companionChar !== undefined) syncData.specialistChar = companionChar;
-        if (teachingScore !== undefined) syncData.teacherScore = teachingScore;
+        syncData.teacherScore = teachingScore ?? 0;
         return syncData;
       }
       case "steward":
@@ -246,7 +246,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
         const profession = InhabitantSchema.getLinkedAbilityStats(actor, "profession", professionLabels);
         const syncData = {};
         if (companionChar !== undefined) syncData.specialistChar = companionChar;
-        if (profession !== undefined) syncData.score = profession.score;
+        syncData.score = profession?.score ?? 0;
         return syncData;
       }
       case "turbCaptain": {
@@ -256,7 +256,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
           : undefined;
         const syncData = {};
         if (companionChar !== undefined) syncData.specialistChar = companionChar;
-        if (leadership !== undefined) syncData.score = leadership;
+        syncData.score = leadership ?? 0;
         return syncData;
       }
       default:
@@ -443,7 +443,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
         }
       case "companions":
         if (["craftsman", "craftsmen"].includes(this.companionRole)) {
-          return this.isSpecialist ? this.score : Math.floor(1 + this.score / 2);
+          return this.isRare ? this.score : Math.floor(1 + this.score / 2);
         }
         return 0;
       case "specialists":

--- a/module/schemas/inhabitantSchema.js
+++ b/module/schemas/inhabitantSchema.js
@@ -100,7 +100,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
         initial: 0,
         step: 1
       }),
-      isSpecialist: new fields.BooleanField({
+      isRare: new fields.BooleanField({
         required: false,
         nullable: false,
         initial: false
@@ -351,7 +351,7 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
   get craftSavings() {
     switch (this.category) {
       case "craftsmen":
-        if (this.isSpecialist) {
+        if (this.isRare) {
           return this.score;
         }
         else {
@@ -449,8 +449,14 @@ export class InhabitantSchema extends foundry.abstract.TypeDataModel {
     // Migrate "other" specialists to specialist craftspeople
     if (data.system.category === "specialists" && data.system.specialistType === "other" && data.system.fieldOfWork !== "none") {
       updateData["system.category"] = "craftsmen";
-      updateData["system.isSpecialist"] = true;
+      updateData["system.isRare"] = true;
       // fieldOfWork is already set, so it carries over
+    }
+    if (typeof data.system.isSpecialist === "boolean") {
+      if (typeof data.system.isRare !== "boolean" && updateData["system.isRare"] === undefined) {
+        updateData["system.isRare"] = data.system.isSpecialist;
+      }
+      updateData["system.-=isSpecialist"] = null;
     }
     if (typeof data.system.loyalty !== "number") {
       updateData["system.loyalty"] = convertToNumber(data.system.loyalty, 0);

--- a/module/sheets/actor/actor-covenant-sheet-v2.js
+++ b/module/sheets/actor/actor-covenant-sheet-v2.js
@@ -167,6 +167,13 @@ export class ArM5eCovenantActorSheetV2 extends ArM5eActorSheetV2 {
       context.system.loyalty.modifiers.specialists += person.system.loyaltyGain;
     }
 
+    for (let person of context.system.inhabitants.companion) {
+      if (person.system.linked) {
+        person.system.yearBorn = person.system.document.system.description.born.value;
+      }
+      context.system.loyalty.modifiers.specialists += person.system.loyaltyGain;
+    }
+
     for (let person of context.system.inhabitants.habitants) {
       if (person.system.linked) {
         person.system.yearBorn = person.system.document.system.description.born.value;
@@ -424,6 +431,7 @@ export class ArM5eCovenantActorSheetV2 extends ArM5eActorSheetV2 {
           system: {
             category: "companions",
             actorId: actor._id,
+            companionRole: "none",
             job: actor.system.description.title.value,
             points: pts,
             yearBorn: actor.system.description.born.value

--- a/module/sheets/actor/actor-covenant-sheet-v2.js
+++ b/module/sheets/actor/actor-covenant-sheet-v2.js
@@ -431,7 +431,7 @@ export class ArM5eCovenantActorSheetV2 extends ArM5eActorSheetV2 {
           system: {
             category: "companions",
             actorId: actor._id,
-            companionRole: "none",
+            companionRole: "other",
             job: actor.system.description.title.value,
             points: pts,
             yearBorn: actor.system.description.born.value

--- a/module/sheets/item/item-inhabitant-sheet-v2.js
+++ b/module/sheets/item/item-inhabitant-sheet-v2.js
@@ -103,10 +103,7 @@ export class ArM5eInhabitantItemSheetV2 extends ArM5eItemSheetV2 {
     }
 
     if (sys.category === "craftsmen" || (sys.category === "companions" && sys.companionRole === "craftsman")) {
-      const linkedActor = game.actors.get(sys.actorId);
-      context.craftSyncAbilities = {
-        "": game.i18n.localize("arm5e.sheet.none")
-      };
+      context.craftSyncAbilities = { "": game.i18n.localize("arm5e.generic.none") };
       const linkedActor = sys.linked ? game.actors.get(sys.actorId) : null;
       if (linkedActor) {
         for (const ability of linkedActor.items.filter((item) => item.type === "ability")) {

--- a/module/sheets/item/item-inhabitant-sheet-v2.js
+++ b/module/sheets/item/item-inhabitant-sheet-v2.js
@@ -96,8 +96,44 @@ export class ArM5eInhabitantItemSheetV2 extends ArM5eItemSheetV2 {
       }
     }
 
+    if (sys.category === "craftsmen" || (sys.category === "companions" && sys.companionRole === "craftsman")) {
+      const linkedActor = game.actors.get(sys.actorId);
+      context.craftSyncAbilities = {
+        "": game.i18n.localize("arm5e.sheet.none")
+      };
+      if (linkedActor) {
+        for (const ability of linkedActor.items.filter((item) => item.type === "ability")) {
+          const score = ability.system?.finalScore ?? ability.system?.score ?? 0;
+          const option = ability.system?.option ? ` (${ability.system.option})` : "";
+          context.craftSyncAbilities[ability.id] = `${ability.name}${option} [${score}]`;
+        }
+      }
+    }
     if (sys.category === "companions") {
       context.companionRoles = foundry.utils.deepClone(CONFIG.ARM5E.covenant.companionRoles);
+      switch (sys.companionRole) {
+        case "teacher":
+          context.companionSpecialistChar = "arm5e.sheet.com";
+          context.companionSpecialistAbility = "arm5e.skill.general.teaching";
+          context.ui.companionTeacherDetails = true;
+          context.ui.companionDetails = true;
+          break;
+        case "steward":
+        case "chamberlain":
+          context.companionSpecialistChar = "arm5e.sheet.pre";
+          context.companionSpecialistAbility = game.i18n.format("arm5e.skill.general.profession", {
+            option: game.i18n.localize(`arm5e.covenant.specialist.${sys.companionRole}`)
+          });
+          context.ui.companionDetails = true;
+          break;
+        case "turbCaptain":
+          context.companionSpecialistChar = "arm5e.sheet.pre";
+          context.companionSpecialistAbility = "arm5e.skill.general.leadership";
+          context.ui.companionDetails = true;
+          break;
+        default:
+          break;
+      }
     }
 
     return context;

--- a/module/sheets/item/item-inhabitant-sheet-v2.js
+++ b/module/sheets/item/item-inhabitant-sheet-v2.js
@@ -96,6 +96,10 @@ export class ArM5eInhabitantItemSheetV2 extends ArM5eItemSheetV2 {
       }
     }
 
+    if (sys.category === "companions") {
+      context.companionRoles = foundry.utils.deepClone(CONFIG.ARM5E.covenant.companionRoles);
+    }
+
     return context;
   }
 

--- a/module/tools/inhabitant-sync.js
+++ b/module/tools/inhabitant-sync.js
@@ -1,0 +1,145 @@
+import { InhabitantSchema } from "../schemas/inhabitantSchema.js";
+
+const SOURCE_ACTOR_TYPES = new Set(["player", "npc", "beast"]);
+const RELEVANT_ACTOR_PATHS = [
+  "name",
+  "img",
+  "system.description.born.value",
+  "system.characteristics.com.value",
+  "system.characteristics.pre.value"
+];
+
+let linkedInhabitants = new Map();
+let indexIsDirty = true;
+const pendingActorIds = new Set();
+let drainScheduled = false;
+let drainRunning = false;
+
+function rebuildIndex() {
+  const nextIndex = new Map();
+
+  for (const covenant of game.actors.filter((actor) => actor.type === "covenant")) {
+    for (const item of covenant.items) {
+      if (item.type !== "inhabitant" || !item.system.actorId) continue;
+      const links = nextIndex.get(item.system.actorId) ?? [];
+      links.push({ covenantId: covenant.id, itemId: item.id });
+      nextIndex.set(item.system.actorId, links);
+    }
+  }
+
+  linkedInhabitants = nextIndex;
+  indexIsDirty = false;
+}
+
+function buildChangedUpdate(item, actor) {
+  const desired = {
+    name: actor.name,
+    img: actor.img,
+    ...Object.fromEntries(
+      Object.entries(InhabitantSchema.getLinkedSyncData(item.system, actor)).map(([key, value]) => [
+        `system.${key}`,
+        value
+      ])
+    )
+  };
+  const update = { _id: item.id };
+
+  for (const [path, value] of Object.entries(desired)) {
+    const current = foundry.utils.getProperty(item, path);
+    if (!Object.is(current, value)) update[path] = value;
+  }
+
+  return Object.keys(update).length > 1 ? update : null;
+}
+
+async function syncActor(actor) {
+  if (!actor || !SOURCE_ACTOR_TYPES.has(actor.type)) return;
+
+  const activeGM = game.users.activeGM;
+  if (activeGM && !activeGM.isSelf) return;
+
+  if (indexIsDirty) rebuildIndex();
+  const links = linkedInhabitants.get(actor.id);
+  if (!links?.length) return;
+
+  const updatesByCovenant = new Map();
+  for (const { covenantId, itemId } of links) {
+    const covenant = game.actors.get(covenantId);
+    if (!covenant?.isOwner) continue;
+
+    const item = covenant.items.get(itemId);
+    if (!item || item.type !== "inhabitant" || item.system.actorId !== actor.id) {
+      indexIsDirty = true;
+      continue;
+    }
+
+    const update = buildChangedUpdate(item, actor);
+    if (!update) continue;
+    const updates = updatesByCovenant.get(covenant) ?? [];
+    updates.push(update);
+    updatesByCovenant.set(covenant, updates);
+  }
+
+  for (const [covenant, updates] of updatesByCovenant) {
+    await covenant.updateEmbeddedDocuments("Item", updates, {
+      render: false,
+      arm5eLinkedInhabitantSync: true
+    });
+    covenant.sheet?.render(false);
+  }
+}
+
+async function drainQueue() {
+  if (drainRunning) return;
+  drainScheduled = false;
+  drainRunning = true;
+
+  try {
+    while (pendingActorIds.size) {
+      const actorIds = [...pendingActorIds];
+      pendingActorIds.clear();
+      for (const actorId of actorIds) {
+        try {
+          await syncActor(game.actors.get(actorId));
+        } catch (error) {
+          console.error("ArM5e | Failed to synchronize linked covenant inhabitants", error);
+        }
+      }
+    }
+  } finally {
+    drainRunning = false;
+    if (pendingActorIds.size) scheduleDrain();
+  }
+}
+
+function scheduleDrain() {
+  if (drainScheduled || drainRunning) return;
+  drainScheduled = true;
+  queueMicrotask(() => void drainQueue());
+}
+
+export function requestLinkedInhabitantSync(actor) {
+  if (!actor || !SOURCE_ACTOR_TYPES.has(actor.type)) return;
+  pendingActorIds.add(actor.id);
+  scheduleDrain();
+}
+
+export function invalidateLinkedInhabitantIndex() {
+  indexIsDirty = true;
+}
+
+function hasChangeAtPath(changes, path) {
+  const changedPaths = Object.keys(foundry.utils.flattenObject(changes));
+  return changedPaths.some(
+    (changedPath) =>
+      changedPath === path || changedPath.startsWith(`${path}.`) || path.startsWith(`${changedPath}.`)
+  );
+}
+
+export function hasRelevantLinkedInhabitantActorChange(changes) {
+  return RELEVANT_ACTOR_PATHS.some((path) => hasChangeAtPath(changes, path));
+}
+
+export function hasLinkedInhabitantActorIdChange(changes) {
+  return hasChangeAtPath(changes, "system.actorId");
+}

--- a/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
+++ b/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
@@ -326,7 +326,7 @@
           <span class="flexrow bold flex05">Qty: {{item.system.quantity}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}: {{item.system.yearBorn}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.loyalty"}}: {{item.system.loyalty}}</span>
-          {{#if item.system.isSpecialist}}<span class="flexrow badge">{{localize "arm5e.sheet.specialist"}}</span>{{/if}}
+          {{#if item.system.isRare}}<span class="flexrow badge">{{localize "arm5e.sheet.rare"}}</span>{{/if}}
         </div>
         <div class="item-controls">
           {{#if (eq item.system.linked true)}}

--- a/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
+++ b/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
@@ -247,7 +247,25 @@
           </span>
           <span class="flexrow bold flex05">{{localize "arm5e.sheet.loyalty"}}:
             {{item.system.loyalty}}</span>
-          </span>
+        <span class="flexrow bold flex05">Covenant role:
+          {{localize (lookup config.covenant.companionRoles item.system.companionRole)}}
+        </span>
+        {{#if (eq item.system.companionRole 'teacher')}}
+        <span class="flexrow bold">{{localize "arm5e.sheet.com"}}: {{item.system.companionRoleChar}}</span>
+        <span class="flexrow bold">{{localize "arm5e.skill.general.teaching"}}:
+          {{item.system.companionTeacherScore}}</span>
+        {{else if (or (eq item.system.companionRole 'steward') (eq item.system.companionRole 'chamberlain') (eq
+        item.system.companionRole 'turbCaptain'))}}
+        <span class="flexrow bold">{{localize "arm5e.sheet.pre"}}: {{item.system.roleChar}}</span>
+        <span class="flexrow bold">{{localize "arm5e.sheet.score"}}: {{item.system.score}}</span>
+        {{else if (eq item.system.companionRole 'craftsman')}}
+        <span class="flexrow bold">{{localize "arm5e.sheet.fieldOfWork"}}:
+          {{localize (lookup config.covenant.fieldOfWork item.system.fieldOfWork)}}
+        </span>
+        <span class="flexrow bold">{{localize "arm5e.sheet.quantity"}}: {{item.system.quantity}}</span>
+        {{#if item.system.isSpecialist}}<span class="flexrow badge">{{localize
+          "arm5e.sheet.specialist"}}</span>{{/if}}
+        {{/if}}
         </div>
         <div class="item-controls">
           {{#if (eq item.system.linked true)}}
@@ -268,9 +286,7 @@
 <ol class="items-list backSection margintop18">
   <li class="item flexrow item-header inhabitants" data-action="toggleInhabitants" data-category="inhabitants-specialists">
     <div class="item-image"></div>
-    <div class="item-name">{{localize "arm5e.sheet.specialists"}} ({{system.census.specialists}}) &
-      {{localize "arm5e.sheet.craftsmen"}} ({{system.census.craftsmen }})
-    </div>
+    <div class="item-name">{{localize "arm5e.sheet.specialists"}} ({{system.census.specialists}})</div>
     <div class="item-controls">
       <a class="item-control item-create" data-action="itemCreate" title="Add Specialist" data-type="inhabitant" data-category="specialists"><i
           class="fas fa-plus"></i>{{localize "arm5e.sheet.action.Create"}}</a>
@@ -299,6 +315,45 @@
           <a class="item-control item-edit" data-action="itemEdit" title="Edit Specialist" data-actorId="{{item.system.actorId}}"><i
               class="ars-Icon_Edit"></i></a>
           <a class="item-control actor-link-delete" data-action="removeLinkedItem" title="Delete Specialist"><i
+              class="ars-Icon_Delete_Hand_Gesture"></i></a>
+        </div>
+      </li>
+    {{/each}}
+  </div>
+</ol>
+
+{{!-- craftsmen --}}
+<ol class="items-list backSection margintop18">
+  <li class="item flexrow item-header inhabitants" data-action="toggleInhabitants"
+    data-category="inhabitants-craftsmen">
+    <div class="item-image"></div>
+    <div class="item-name">{{localize "arm5e.sheet.craftsmen"}} ({{system.census.craftsmen}})</div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-action="itemCreate" title="Add Craftsperson" data-type="inhabitant"
+        data-category="craftsmen"><i class="fas fa-plus"></i>{{localize "arm5e.sheet.action.Create"}}</a>
+    </div>
+  </li>
+  <div id="inhabitants-craftsmen" class="toggle-collapse {{ui.lists.visibility.inhabitants.inhabitants-craftsmen}}">
+    {{> (systemPath "templates/generic/metalic-bar.html") }}
+    {{#each system.inhabitants.craftsmen as |item id|}}
+    <li class="item item-value flexrow flex-center" data-name="{{item.name}}" data-attribute="{{id}}"
+      data-item-id="{{item._id}}">
+      <div class="item-image item-control item-edit" data-action="itemEdit"><img src="{{item.img}}"
+          title="{{item.name}}" /></div>
+      <div class="flexrow flex-center">
+        <span class="flexrow item-title width15">{{item.name}}</span>
+        <span class="flexrow bold width15">{{item.system.job}} ({{item.system.score}})</span>
+        <span class="flexrow bold">{{localize "arm5e.sheet.fieldOfWork"}}:
+          {{localize (lookup config.covenant.fieldOfWork item.system.fieldOfWork)}}
+        </span>
+        <span class="flexrow bold flex05">Qty: {{item.system.quantity}}</span>
+        {{#if item.system.isSpecialist}}<span class="flexrow badge">{{localize
+          "arm5e.sheet.specialist"}}</span>{{/if}}
+      </div>
+      <div class="item-controls">
+        <a class="item-control item-edit" data-action="itemEdit" title="Edit Craftsperson"><i
+            class="ars-Icon_Edit"></i></a>
+        <a class="item-control actor-link-delete" data-action="removeLinkedItem" title="Delete Craftsperson"><i
               class="ars-Icon_Delete_Hand_Gesture"></i></a>
         </div>
       </li>

--- a/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
+++ b/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
@@ -261,9 +261,9 @@
           <span class="flexrow bold">{{localize "arm5e.sheet.fieldOfWork"}}:
             {{localize (lookup config.covenant.fieldOfWork item.system.fieldOfWork)}}
           </span>
-          <span class="flexrow bold">{{localize "arm5e.sheet.quantity"}}: {{item.system.quantity}}</span>
-          {{#if item.system.isSpecialist}}<span class="flexrow badge">{{localize
-            "arm5e.sheet.specialist"}}</span>{{/if}}
+          <span class="flexrow bold">{{localize "arm5e.sheet.score"}}: {{item.system.score}}</span>
+          {{#if item.system.isRare}}<span class="flexrow badge">{{localize
+            "arm5e.sheet.rare"}}</span>{{/if}}
           {{/if}}
         </div>
         <div class="item-controls">

--- a/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
+++ b/templates/actor/parts/actor-covenant-inhabitants-tab-v2.hbs
@@ -240,15 +240,15 @@
             title="{{item.name}}" /></div>
         <div class="flexrow flex-center">
           <span class="flexrow item-title width15">{{item.name}}</span>
-          <label><span class="flexrow bold width15"></span>{{item.system.job}}</label>
+          <span class="flexrow bold width15">{{item.system.job}}</span>
+          {{#if (eq item.system.companionRole 'craftsman')}}
+          <span class="flexrow bold">{{localize "arm5e.sheet.score"}}: {{item.system.score}}</span>
+          {{/if}}
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}:
             {{item.system.yearBorn}}
           </span>
           <span class="flexrow bold flex05">{{localize "arm5e.sheet.loyalty"}}:
             {{item.system.loyalty}}</span>
-          <span class="flexrow bold flex05">Covenant role:
-            {{localize (lookup config.covenant.companionRoles item.system.companionRole)}}
-          </span>
           {{#if (eq item.system.companionRole 'teacher')}}
           <span class="flexrow bold">{{localize "arm5e.sheet.com"}}: {{item.system.companionRoleChar}}</span>
           <span class="flexrow bold">{{localize "arm5e.skill.general.teaching"}}:
@@ -256,12 +256,14 @@
           {{else if (or (eq item.system.companionRole 'steward') (eq item.system.companionRole 'chamberlain') (eq
           item.system.companionRole 'turbCaptain'))}}
           <span class="flexrow bold">{{localize "arm5e.sheet.pre"}}: {{item.system.roleChar}}</span>
-          <span class="flexrow bold">{{localize "arm5e.sheet.score"}}: {{item.system.score}}</span>
+          {{#if (eq item.system.companionRole 'turbCaptain')}}
+          <span class="flexrow bold">{{localize "arm5e.skill.general.leadership"}}: {{item.system.score}}</span>
+          {{else}}
+          <span class="flexrow bold">{{localize "arm5e.skill.general.profession"
+            option=(localize (concat "arm5e.covenant.specialist." item.system.companionRole))}}:
+            {{item.system.score}}</span>
+          {{/if}}
           {{else if (eq item.system.companionRole 'craftsman')}}
-          <span class="flexrow bold">{{localize "arm5e.sheet.fieldOfWork"}}:
-            {{localize (lookup config.covenant.fieldOfWork item.system.fieldOfWork)}}
-          </span>
-          <span class="flexrow bold">{{localize "arm5e.sheet.score"}}: {{item.system.score}}</span>
           {{#if item.system.isRare}}<span class="flexrow badge">{{localize
             "arm5e.sheet.rare"}}</span>{{/if}}
           {{/if}}
@@ -307,6 +309,21 @@
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}: {{item.system.yearBorn}} </span>
           <span class="flexrow bold flex05">{{localize "arm5e.sheet.loyalty"}}: {{item.system.loyalty}}
           </span>
+          {{#if (eq item.system.specialistType 'teacher')}}
+          <span class="flexrow bold">{{localize "arm5e.sheet.com"}}: {{item.system.specialistChar}}</span>
+          <span class="flexrow bold">{{localize "arm5e.skill.general.teaching"}}:
+            {{item.system.teacherScore}}</span>
+          {{else if (or (eq item.system.specialistType 'steward') (eq item.system.specialistType 'chamberlain') (eq
+          item.system.specialistType 'turbCaptain'))}}
+          <span class="flexrow bold">{{localize "arm5e.sheet.pre"}}: {{item.system.specialistChar}}</span>
+          {{#if (eq item.system.specialistType 'turbCaptain')}}
+          <span class="flexrow bold">{{localize "arm5e.skill.general.leadership"}}: {{item.system.score}}</span>
+          {{else}}
+          <span class="flexrow bold">{{localize "arm5e.skill.general.profession"
+            option=(localize (concat "arm5e.covenant.specialist." item.system.specialistType))}}:
+            {{item.system.score}}</span>
+          {{/if}}
+          {{/if}}
         </div>
         <div class="item-controls">
           {{#if (eq item.system.linked true)}}
@@ -345,7 +362,8 @@
             title="{{item.name}}" /></div>
         <div class="flexrow flex-center">
           <span class="flexrow item-title width15">{{item.name}}</span>
-          <span class="flexrow bold width15">{{localize "arm5e.sheet.job"}}: {{item.system.job}}</span>
+          <span class="flexrow bold width15">{{item.system.job}}</span>
+          <span class="flexrow bold">{{localize "arm5e.sheet.score"}}: {{item.system.score}}</span>
           <span class="flexrow bold flex05">Qty: {{item.system.quantity}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.yearBorn"}}: {{item.system.yearBorn}}</span>
           <span class="flexrow bold">{{localize "arm5e.sheet.loyalty"}}: {{item.system.loyalty}}</span>

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -112,6 +112,44 @@
           <select name="system.fieldOfWork" data-type="String">
             {{selectOptions config.covenant.fieldOfWork selected=system.fieldOfWork localize=true}}
           </select>
+        </div><div class="resource flexcol flex0 flex-center">
+          <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
+          <div class="flexrow flex-group-center">
+            <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+          </div>
+        </div>
+        <div class="resource flexcol">
+          <label class="bold">Linked ability</label>
+          <select name="system.syncAbilityId" data-type="String">
+            {{selectOptions craftSyncAbilities selected=system.syncAbilityId}}
+          </select>
+        </div>
+        <div class="resource flexcol flex0">
+          <label class="bold">{{localize 'arm5e.sheet.quantity'}}</label>
+          <input class="select-on-focus" type="number" name="system.quantity" value="{{ system.quantity }}"
+            data-dtype="Number" />
+        </div>
+        {{else if (eq system.companionRole 'teacher')}}
+        <div class="resource flexcol">
+          <label class="bold">{{localize companionSpecialistChar}}</label>
+          <input class="select-on-focus" type="number" name="system.specialistChar" value="{{ system.specialistChar }}"
+            data-dtype="Number" />
+        </div>
+        <div class="resource flexcol">
+          <label class="bold">{{localize companionSpecialistAbility}}</label>
+          <input class="select-on-focus" type="number" name="system.teacherScore" value="{{ system.teacherScore }}"
+            data-dtype="Number" />
+        </div>
+        {{else if (or (eq system.companionRole 'steward') (eq system.companionRole 'chamberlain') (eq
+        system.companionRole 'turbCaptain'))}}
+        <div class="resource flexcol">
+          <label class="bold">{{localize companionSpecialistChar}}</label>
+          <input class="select-on-focus" type="number" name="system.specialistChar" value="{{ system.specialistChar }}"
+            data-dtype="Number" />
+        </div>
+        <div class="resource flexcol">
+          <label class="bold">{{localize companionSpecialistAbility}}</label>
+          <input class="select-on-focus" type="number" name="system.score" value="{{ system.score }}" data-dtype="Number" />
         </div>
         {{/if}}
       </div>
@@ -252,6 +290,62 @@
           <select name="system.fieldOfWork" data-type="String">
             {{selectOptions config.covenant.fieldOfWork selected=system.fieldOfWork localize=true}}
           </select>
+        </div><div class="resource flexcol flex0 flex-center">
+          <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
+          <div class="flexrow flex-group-center">
+            <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+          </div>
+        </div>
+      </div>
+      <div class="flexrow">
+        <div class="resource flexcol">
+          <label class="bold">Linked ability</label>
+          <select name="system.syncAbilityId" data-type="String">
+            {{selectOptions craftSyncAbilities selected=system.syncAbilityId}}
+          </select>
+        </div>
+        <div class="resource flexcol flex0">
+          <label class="bold">{{localize 'arm5e.sheet.quantity'}}</label>
+          <input class="select-on-focus" type="number" name="system.quantity" value="{{ system.quantity }}"
+            data-dtype="Number" />
+        </div>
+        <div class="resource flexcol flex0 flex-center">
+          <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
+          <div class="flexrow flex-group-center">
+            <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+          </div>
+        </div>
+      </div>
+      <div class="flexrow">
+        <div class="resource flexcol">
+          <label class="bold">Linked ability</label>
+          <select name="system.syncAbilityId" data-type="String">
+            {{selectOptions craftSyncAbilities selected=system.syncAbilityId}}
+          </select>
+        </div>
+        <div class="resource flexcol flex0">
+          <label class="bold">{{localize 'arm5e.sheet.quantity'}}</label>
+          <input class="select-on-focus" type="number" name="system.quantity" value="{{ system.quantity }}"
+            data-dtype="Number" />
+        </div>
+      <div class="resource flexcol flex0 flex-center">
+        <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
+        <div class="flexrow flex-group-center">
+          <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+        </div>
+      </div>
+      </div>
+      <div class="flexrow">
+        <div class="resource flexcol">
+          <label class="bold">Linked ability</label>
+          <select name="system.syncAbilityId" data-type="String">
+            {{selectOptions craftSyncAbilities selected=system.syncAbilityId}}
+          </select>
+        </div>
+        <div class="resource flexcol flex0">
+          <label class="bold">{{localize 'arm5e.sheet.quantity'}}</label>
+          <input class="select-on-focus" type="number" name="system.quantity" value="{{ system.quantity }}"
+            data-dtype="Number" />
         </div>
       </div>
 

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -99,6 +99,22 @@
           <input type="text" name="system.score" value="{{ system.score }}" data-dtype="Number" />
         </div>
       </div>
+      <div class="flexrow">
+        <div class="resource flexcol">
+          <label class="bold">Covenant role</label>
+          <select name="system.companionRole" data-type="String">
+            {{selectOptions companionRoles selected=system.companionRole labelAttr='label' localize=true}}
+          </select>
+        </div>
+        {{#if (eq system.companionRole 'craftsman')}}
+        <div class="resource flexcol">
+          <label class="bold">{{localize 'arm5e.sheet.fieldOfWork'}}</label>
+          <select name="system.fieldOfWork" data-type="String">
+            {{selectOptions config.covenant.fieldOfWork selected=system.fieldOfWork localize=true}}
+          </select>
+        </div>
+        {{/if}}
+      </div>
       <div class="resource flexrow">
         <div class="resource flexcol">
           <label class="bold">{{localize 'arm5e.sheet.loyalty'}}</label>

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -124,7 +124,7 @@
         </div>
       </div>
 
-      {{!-- craftsmen: job, score, fieldOfWork, quantity, isSpecialist --}}
+      {{!-- craftsmen: job, score, fieldOfWork, quantity, isRare --}}
       {{else if (eq system.category 'craftsmen')}}
       <div class="flexrow">
         <div class="resource flexcol">
@@ -150,9 +150,9 @@
           </select>
         </div>
         <div class="resource flexcol flex0 flex-center">
-          <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
+          <label class="bold">{{localize 'arm5e.sheet.rare'}}</label>
           <div class="flexrow flex-group-center">
-            <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+            <input type="checkbox" name="system.isRare" {{checked system.isRare}} />
           </div>
         </div>
       </div>

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -67,20 +67,34 @@
           </select>
         </div>
       </div>
-      {{!-- companions: job --}}
+      {{!-- companions: job, covenant role, and matching specialist/craftsman details --}}
       {{else if (eq system.category 'companions')}}
-      <div class="resource flexcol">
-        <label class="bold">{{localize 'arm5e.sheet.job'}}</label>
-        <input type="text" name="system.job" value="{{ system.job }}" data-dtype="String" />
-      </div>
       <div class="flexrow">
         <div class="resource flexcol">
-          <label class="bold">Covenant role</label>
-          <select name="system.companionRole" data-type="String">
-            {{selectOptions companionRoles selected=system.companionRole labelAttr='label' localize=true}}
-          </select>
+          <label class="bold">{{localize 'arm5e.sheet.job'}}</label>
+          <input type="text" name="system.job" value="{{ system.job }}" data-dtype="String" />
         </div>
         {{#if (eq system.companionRole 'craftsman')}}
+        <div class="resource flexcol flex0">
+          <label class="bold">{{localize 'arm5e.sheet.score'}}</label>
+          <input
+            class="select-on-focus"
+            type="number"
+            name="system.score"
+            value="{{ system.score }}"
+            data-dtype="Number"
+          />
+        </div>
+        {{/if}}
+      </div>
+      <div class="resource flexcol">
+        <label class="bold">Covenant role</label>
+        <select name="system.companionRole" data-type="String">
+          {{selectOptions companionRoles selected=system.companionRole labelAttr='label' localize=true}}
+        </select>
+      </div>
+      {{#if (eq system.companionRole 'craftsman')}}
+      <div class="flexrow">
         <div class="resource flexcol">
           <label class="bold">{{localize 'arm5e.sheet.fieldOfWork'}}</label>
           <select name="system.fieldOfWork" data-type="String">
@@ -88,31 +102,67 @@
           </select>
         </div>
         <div class="resource flexcol flex0 flex-center">
-          <label class="bold">{{localize 'arm5e.sheet.specialist'}}</label>
-          <input type="checkbox" name="system.isSpecialist" {{checked system.isSpecialist}} />
+          <label class="bold">{{localize 'arm5e.sheet.rare'}}</label>
+          <div class="flexrow flex-group-center">
+            <input type="checkbox" name="system.isRare" {{checked system.isRare}} />
+          </div>
         </div>
+      </div>
+      <div class="flexrow">
         <div class="resource flexcol">
           <label class="bold">Linked ability</label>
           <select name="system.syncAbilityId" data-type="String">
             {{selectOptions craftSyncAbilities selected=system.syncAbilityId}}
           </select>
         </div>
-        {{else if (eq system.companionRole 'teacher')}}
+      </div>
+      {{else if (eq system.companionRole 'teacher')}}
+      <div class="flexrow">
         <div class="resource flexcol">
           <label class="bold">{{localize companionSpecialistChar}}</label>
-          <input class="select-on-focus" type="number" name="system.specialistChar" value="{{ system.specialistChar }}" data-dtype="Number" />
+          <input
+            class="select-on-focus"
+            type="number"
+            name="system.specialistChar"
+            value="{{ system.specialistChar }}"
+            data-dtype="Number"
+          />
         </div>
         <div class="resource flexcol">
           <label class="bold">{{localize companionSpecialistAbility}}</label>
-          <input class="select-on-focus" type="number" name="system.teacherScore" value="{{ system.teacherScore }}" data-dtype="Number" />
+          <input
+            class="select-on-focus"
+            type="number"
+            name="system.teacherScore"
+            value="{{ system.teacherScore }}"
+            data-dtype="Number"
+          />
         </div>
-        {{else if (or (eq system.companionRole 'steward') (eq system.companionRole 'chamberlain') (eq system.companionRole 'turbCaptain'))}}
+      </div>
+      {{else if (or (eq system.companionRole 'steward') (eq system.companionRole 'chamberlain') (eq system.companionRole 'turbCaptain'))}}
+      <div class="flexrow">
         <div class="resource flexcol">
           <label class="bold">{{localize companionSpecialistChar}}</label>
-          <input class="select-on-focus" type="number" name="system.specialistChar" value="{{ system.specialistChar }}" data-dtype="Number" />
+          <input
+            class="select-on-focus"
+            type="number"
+            name="system.specialistChar"
+            value="{{ system.specialistChar }}"
+            data-dtype="Number"
+          />
         </div>
-        {{/if}}
+        <div class="resource flexcol">
+          <label class="bold">{{localize companionSpecialistAbility}}</label>
+          <input
+            class="select-on-focus"
+            type="number"
+            name="system.score"
+            value="{{ system.score }}"
+            data-dtype="Number"
+          />
+        </div>
       </div>
+      {{/if}}
       {{!-- specialists: job, score for the "other" type, specialist details and type --}}
       {{else if (eq system.category 'specialists')}}
       <div class="flexrow">

--- a/templates/item/parts/item-inhabitant-header-v2.hbs
+++ b/templates/item/parts/item-inhabitant-header-v2.hbs
@@ -94,10 +94,12 @@
             {{ui.canEdit}}
           />
         </div>
+        {{#if (eq system.companionRole 'craftsman')}}
         <div class="resource flexcol">
           <label class="bold">{{localize 'arm5e.sheet.score'}}</label>
           <input type="text" name="system.score" value="{{ system.score }}" data-dtype="Number" />
         </div>
+        {{/if}}
       </div>
       <div class="flexrow">
         <div class="resource flexcol">
@@ -124,11 +126,6 @@
             {{selectOptions craftSyncAbilities selected=system.syncAbilityId}}
           </select>
         </div>
-        <div class="resource flexcol flex0">
-          <label class="bold">{{localize 'arm5e.sheet.quantity'}}</label>
-          <input class="select-on-focus" type="number" name="system.quantity" value="{{ system.quantity }}"
-            data-dtype="Number" />
-        </div>
         {{else if (eq system.companionRole 'teacher')}}
         <div class="resource flexcol">
           <label class="bold">{{localize companionSpecialistChar}}</label>
@@ -146,10 +143,6 @@
           <label class="bold">{{localize companionSpecialistChar}}</label>
           <input class="select-on-focus" type="number" name="system.specialistChar" value="{{ system.specialistChar }}"
             data-dtype="Number" />
-        </div>
-        <div class="resource flexcol">
-          <label class="bold">{{localize companionSpecialistAbility}}</label>
-          <input class="select-on-focus" type="number" name="system.score" value="{{ system.score }}" data-dtype="Number" />
         </div>
         {{/if}}
       </div>


### PR DESCRIPTION
### This is built off of [PR #501](https://github.com/Xzotl42/arm5e/pull/501)

# Companion Covenant Roles

## Summary

This PR allows companions to serve in covenant specialist and craft roles without changing their inhabitant category. A companion can now be assigned as a teacher, steward, chamberlain, turb captain, craftsperson, or an unclassified "other" role.

Role-specific characteristics and abilities are taken from the linked companion, and the resulting values participate in the same covenant calculations as their specialist or craftsperson equivalents.

The inhabitant sheets and covenant overview have also been updated so companion roles display the information relevant to their work without adding redundant labels or fields.

## Companion Roles

Companion inhabitants now have a covenant-role selector with the following choices:

- Teacher
- Steward
- Chamberlain
- Turb captain
- Craftsperson
- Other

New companions default to `Other`. Legacy companion records using the earlier `none` value are normalized to `Other`.

### Linked role values

When a companion is linked to an actor, its role uses the same source values as the equivalent specialist or craftsperson:

| Companion role | Characteristic | Ability |
| --- | --- | --- |
| Teacher | Communication | Teaching |
| Steward | Presence | Profession (Steward) |
| Chamberlain | Presence | Profession (Chamberlain) |
| Turb captain | Presence | Leadership |
| Craftsperson | — | Selected linked craft ability |

Profession matching also considers the inhabitant's responsibilities text, allowing a steward or chamberlain to match an appropriately named Profession ability.

If a linked role ability cannot be found, its synchronized score falls back to zero instead of retaining an obsolete value.

## Covenant Calculations

Companion roles now contribute to covenant calculations alongside existing inhabitants:

- Companion teachers contribute their teaching build points.
- Companion stewards, chamberlains, and turb captains contribute their role-based loyalty modifier.
- Companion craftspeople contribute savings to their selected field of work.
- Rare companion craftspeople use their full craft score; ordinary companion craftspeople use the standard `1 + score / 2`, rounded down, calculation.
- Companion inhabitants continue to represent one person, so no quantity control or quantity value is shown for companion craftspeople.

## Inhabitant Sheet Changes

The companion inhabitant sheet now adapts to the selected covenant role:

- Teachers show Communication and Teaching.
- Stewards and chamberlains show Presence and their specialized Profession score.
- Turb captains show Presence and Leadership.
- Craftspeople show score, field of work, rare status, and a linked-ability selector.
- The linked-ability selector always has a valid `None` option, including when the linked actor has no abilities. This prevents the sheet-rendering error caused by passing an undefined option list to Handlebars.

The companion craftsperson role uses the singular localized label `Craftsperson`; the existing covenant section heading remains the plural `Craftspeople`.

## Covenant Overview Changes

The inhabitants overview now presents companions and specialists consistently:

- Responsibilities remain visible without the redundant `Responsibilities:` prefix.
- Companion and regular craftspeople display `Score:`.
- Teachers display Communication and Teaching.
- Stewards and chamberlains display Presence and their named Profession ability.
- Turb captains display Presence and Leadership.
- Companion craftsperson quantity is hidden because it is always one.
- Internal `Covenant role` and specialist `Type` fields are hidden; the named characteristic and ability already make the role clear.
- Rare companion craftspeople display the same rare badge as regular rare craftspeople.

## Localization

A new singular `arm5e.sheet.craftsperson` localization key has been added for:

- English
- Spanish
- French
- Italian
- Portuguese
- Brazilian Portuguese

Existing plural craftsperson labels are unchanged.

## Compatibility

- No new actor or item document type is introduced.
- Companions without a specialized role retain the existing `Other` behavior.
- Existing specialist and craftsperson calculations remain available and are reused for companion roles.
- Legacy companion role value `none` is migrated to `other`.
- This PR expects the separate inhabitant synchronization optimization PR to be merged first.
