### PR TITLE
Fix/dont count companion build points

### DIFF
--- a/module/schemas/covenantSchema.js
+++ b/module/schemas/covenantSchema.js
@@ -881,12 +881,6 @@ export class CovenantSchema extends foundry.abstract.TypeDataModel {
       }
     }
 
-
-    for (let companion of this.inhabitants.companion) {
-      if (companion.system.companionRole === "teacher") {
-        specialistPts += companion.system.buildPoints;
-      }
-    }
     for (let companion of this.inhabitants.companion) {
       if (companion.system.companionRole === "craftsman" && companion.system.fieldOfWork !== "none") {
         let craft = slugify(companion.system.job, false);

--- a/module/schemas/covenantSchema.js
+++ b/module/schemas/covenantSchema.js
@@ -869,7 +869,7 @@ export class CovenantSchema extends foundry.abstract.TypeDataModel {
     );
 
     for (let craft of this.inhabitants.craftsmen) {
-      if (craft.system.fieldOfWork !== "books") {
+      if (craft.system.fieldOfWork !== "books" && craft.system.fieldOfWork !== "none") {
         let craftName = slugify(craft.system.job, false);
         let saves = craft.system.craftSavings * craft.system.number;
         if (!craftSavings[craft.system.fieldOfWork].crafts[craftName]) {


### PR DESCRIPTION
### Built from [pr503](https://github.com/Xzotl42/arm5e/pull/503)

Initially companions with roles were being counted for the purpose of build points, this shouldn't be the case for named characters. This removes companion teachers from counting for build points.